### PR TITLE
Add support for intro and ih.

### DIFF
--- a/Smt/Constants.lean
+++ b/Smt/Constants.lean
@@ -10,10 +10,12 @@ open Smt.Term
 open Smt.Solver
 open Lean
 
-def natMinus : Expr := mkConst (Name.mkSimple "Nat.sub")
+def natMinus : Expr := mkConst `Nat.sub
+
+def defNat (s : Solver) : Solver := defineSort s "Nat" [] (Symbol "Int")
 
 def defNatSub (s : Solver) : Solver :=
-   defineFun s "Nat.sub" [("x", `"Int"), ("y", `"Int")] (`"Int") $
+   defineFun s "Nat.sub" [("x", `"Nat"), ("y", `"Nat")] (`"Nat") $
     `"ite" • (`"<" • `"x" • `"y") • ``"0" • (`"-" • `"x" • `"y")
 
 end Constants

--- a/Smt/Tactic.lean
+++ b/Smt/Tactic.lean
@@ -71,7 +71,7 @@ def parseTactic : Syntax → TacticM (List Expr)
   | `(tactic| smt [$[$hs],*]) => hs.toList.mapM (fun h => elabTerm h none)
   | _                    => throwUnsupportedSyntax
 
-@[tactic smt] def evalSmt : Tactic := fun stx => do
+@[tactic smt] def evalSmt : Tactic := fun stx => withMainContext do
   -- 1. Get the current main goal.
   let goalType ← Tactic.getMainTarget
   let goalId ← Lean.mkFreshFVarId

--- a/Smt/Util.lean
+++ b/Smt/Util.lean
@@ -44,6 +44,20 @@ def getFVars : Expr → List Expr
   | fvar id d       => [fvar id d]
   | _               => []
 
+/-- Returns all meta variables in the given expression. -/
+def getMVars : Expr → List Expr
+  | forallE _ d b _ => getMVars d ++ getMVars b
+  | lam _ d b _     => getMVars d ++ getMVars b
+  | letE _ t v b _  => getMVars t ++ getMVars v ++ getMVars b
+  | app f a _       => getMVars f ++ getMVars a
+  | mdata _ b _     => getMVars b
+  | proj _ _ b _    => getMVars b
+  | mvar id d       => [mvar id d]
+  | _               => []
+
+/-- Does the expression `e` contain meta variables? -/
+def hasMVars (e : Expr) : Bool := !(getMVars e).isEmpty
+
 /-- Converts the given constant into the corresponding SMT constant/function
     symbol. -/
 def knownConsts : Std.HashMap String String :=

--- a/Test/Nat/ZeroSub'.expected
+++ b/Test/Nat/ZeroSub'.expected
@@ -1,0 +1,21 @@
+goal: 0 - Nat.zero = 0
+
+query:
+(define-sort Nat () Int)
+(define-fun Nat.sub ((x Nat) (y Nat)) Nat (ite (< x y) 0 (- x y)))
+(assert (not (= (Nat.sub 0 0) 0)))
+(check-sat)
+
+result: unsat
+goal: 0 - Nat.succ x = 0
+
+query:
+(define-sort Nat () Int)
+(declare-const x Nat)
+(assert (>= x 0))
+(define-fun Nat.sub ((x Nat) (y Nat)) Nat (ite (< x y) 0 (- x y)))
+(assert (not (= (Nat.sub 0 (+ x 1)) 0)))
+(assert (= (Nat.sub 0 x) 0))
+(check-sat)
+
+result: unsat

--- a/Test/Nat/ZeroSub'.lean
+++ b/Test/Nat/ZeroSub'.lean
@@ -1,7 +1,7 @@
 import Smt
 
-/- theorem zero_sub : ∀ x, 0 - x = 0 := by
-  smt
+theorem zero_sub' : ∀ x, 0 - x = 0 := by
   intro x
-  induction x <;> /- smt <;> -/ simp_all [Nat.sub_succ]
--/
+  induction x with
+  | zero => smt; rfl
+  | succ x ih => smt [ih]; simp [ih, Nat.sub_succ]

--- a/Test/Nat/ZeroSub.expected
+++ b/Test/Nat/ZeroSub.expected
@@ -1,10 +1,10 @@
 goal: 0 - x = 0
 
 query:
-(define-fun Nat.sub ((x Int) (y Int)) Int (ite (< x y) 0 (- x y)))
 (define-sort Nat () Int)
 (declare-const x Nat)
 (assert (>= x 0))
+(define-fun Nat.sub ((x Nat) (y Nat)) Nat (ite (< x y) 0 (- x y)))
 (assert (not (= (Nat.sub 0 x) 0)))
 (check-sat)
 

--- a/Test/Nat/ZeroSub.lean
+++ b/Test/Nat/ZeroSub.lean
@@ -1,6 +1,5 @@
 import Smt
 
-
 theorem zero_sub : 0 - x = 0 := by
   smt
   induction x <;> simp_all [Nat.sub_succ]


### PR DESCRIPTION
This PR adds support for context changes introduced by other tactics (e.g., `intro` and `induction`). It also changes the signature of `Nat.sub` to use `Nat` instead of `Int`.