### PR TITLE
Use constant exprs instead of constant strings.

### DIFF
--- a/Smt/Constants.lean
+++ b/Smt/Constants.lean
@@ -32,7 +32,6 @@ def knownConsts : Std.HashMap Expr (Option Expr) :=
     (mkConst `BEq.beq [levelZero], mkConst (Name.mkSimple "=")),
     (mkConst `Bool.true, mkConst `true),
     (mkConst `Bool.false, mkConst `false),
-    (mkConst `Nat.natAbs, mkConst `abs),
 
     (mkConst `Neg.neg [levelZero], mkConst (Name.mkSimple "-")),
     (mkConst `HAdd.hAdd levelsZero, mkConst (Name.mkSimple "+")),

--- a/Smt/Constants.lean
+++ b/Smt/Constants.lean
@@ -10,13 +10,50 @@ open Smt.Term
 open Smt.Solver
 open Lean
 
-def natMinus : Expr := mkConst `Nat.sub
-
 def defNat (s : Solver) : Solver := defineSort s "Nat" [] (Symbol "Int")
 
 def defNatSub (s : Solver) : Solver :=
    defineFun s "Nat.sub" [("x", `"Nat"), ("y", `"Nat")] (`"Nat") $
     `"ite" • (`"<" • `"x" • `"y") • ``"0" • (`"-" • `"x" • `"y")
+
+/-- Map from known constants to corresponding SMT constant/function symbols. -/
+def knownConsts : Std.HashMap Expr (Option Expr) :=
+  List.foldr (fun (k, v) m => m.insert k v) Std.HashMap.empty
+  [
+    (mkConst `Eq [levelOne], mkConst (Name.mkSimple "=")),
+    (mkConst `Ne [levelOne], mkConst `distinct),
+    (mkConst `Prop, mkConst `Bool),
+    (mkConst `True, mkConst `true),
+    (mkConst `False, mkConst `false),
+    (mkConst `Not, mkConst `not),
+    (mkConst `And, mkConst `and),
+    (mkConst `Or, mkConst `or),
+    (mkConst `Iff, mkConst (Name.mkSimple "=")),
+    (mkConst `BEq.beq [levelZero], mkConst (Name.mkSimple "=")),
+    (mkConst `Bool.true, mkConst `true),
+    (mkConst `Bool.false, mkConst `false),
+    (mkConst `Nat.natAbs, mkConst `abs),
+
+    (mkConst `Neg.neg, mkConst (Name.mkSimple "-")),
+    (mkConst `HAdd.hAdd levelsZero, mkConst (Name.mkSimple "+")),
+    (mkConst `HSub.hSub levelsZero, mkConst (Name.mkSimple "-")),
+    (mkConst `HMul.hMul levelsZero, mkConst (Name.mkSimple "*")),
+    (mkConst `HDiv.hDiv levelsZero, mkConst (Name.mkSimple "/")),
+    (mkConst `HMod.hMod levelsZero, mkConst `mod),
+    (mkConst `LT.lt [levelZero], mkConst (Name.mkSimple "<")),
+    (mkConst `GT.gt [levelZero], mkConst (Name.mkSimple ">")),
+    (mkConst `LE.le [levelZero], mkConst (Name.mkSimple "<=")),
+    (mkConst `GE.ge [levelZero], mkConst (Name.mkSimple ">=")),
+
+    (mkApp2 (mkConst `HSub.hSub levelsZero) (mkConst `Nat) (mkConst `Nat),
+     mkConst `Nat.sub),
+    (mkApp2 (mkConst `HDiv.hDiv levelsZero) (mkConst `Nat) (mkConst `Nat),
+     mkConst `div),
+    (mkApp2 (mkConst `HDiv.hDiv levelsZero) (mkConst `Int) (mkConst `Int),
+     mkConst `div)
+  ]
+  where
+    levelsZero := [levelZero, levelZero, levelZero]
 
 end Constants
 end Smt

--- a/Smt/Constants.lean
+++ b/Smt/Constants.lean
@@ -34,7 +34,7 @@ def knownConsts : Std.HashMap Expr (Option Expr) :=
     (mkConst `Bool.false, mkConst `false),
     (mkConst `Nat.natAbs, mkConst `abs),
 
-    (mkConst `Neg.neg, mkConst (Name.mkSimple "-")),
+    (mkConst `Neg.neg [levelZero], mkConst (Name.mkSimple "-")),
     (mkConst `HAdd.hAdd levelsZero, mkConst (Name.mkSimple "+")),
     (mkConst `HSub.hSub levelsZero, mkConst (Name.mkSimple "-")),
     (mkConst `HMul.hMul levelsZero, mkConst (Name.mkSimple "*")),

--- a/Test/Int/Neg.expected
+++ b/Test/Int/Neg.expected
@@ -1,0 +1,8 @@
+goal: - -x = x
+
+query:
+(declare-const x Int)
+(assert (not (= (- (- x)) x)))
+(check-sat)
+
+result: unsat

--- a/Test/Int/Neg.lean
+++ b/Test/Int/Neg.lean
@@ -1,0 +1,7 @@
+import Smt
+
+theorem neg (x : Int) : - -x = x := by
+  smt
+  induction x with
+  | ofNat n   => induction n <;> simp only [Neg.neg, Int.neg, Int.negOfNat]
+  | negSucc n => simp only [Neg.neg, Int.neg, Int.negOfNat]


### PR DESCRIPTION
Currently, we match against the name of type classes like `LE.le` and replace them with corresponding SMT names like `<`. However, that is not always accurate as operators like `<` are overloaded for many types in Lean. Whereas `=` is the only overloaded operator in SMT-LIB. Other operators are not overloaded. For example, less than is represented by `<` for integers and `str.<` for strings. This PR addresses this issue by matching against the type class **_and_** its type arguments and maps that to the appropriate SMT-LIB function symbol.