### PR TITLE
Add support for `exists` quantifier.

### DIFF
--- a/Smt/Constants.lean
+++ b/Smt/Constants.lean
@@ -29,6 +29,7 @@ def knownConsts : Std.HashMap Expr (Option Expr) :=
     (mkConst `And, mkConst `and),
     (mkConst `Or, mkConst `or),
     (mkConst `Iff, mkConst (Name.mkSimple "=")),
+    (mkConst `Exists [levelOne], mkConst `exists),
     (mkConst `BEq.beq [levelZero], mkConst (Name.mkSimple "=")),
     (mkConst `Bool.true, mkConst `true),
     (mkConst `Bool.false, mkConst `false),

--- a/Smt/Term.lean
+++ b/Smt/Term.lean
@@ -7,6 +7,7 @@ inductive Term where
   | Arrow   : Term → Term → Term          -- Function sorts
   | App     : Term → Term → Term          -- Function application
   | Forall  : String → Term → Term → Term -- Forall quantifier
+  | Exists  : String → Term → Term → Term -- Exists quantifier
   deriving Inhabited
 
 namespace Term
@@ -39,6 +40,7 @@ partial def toString : Term → String
     let ts := List.reverse <| appToList (App f t)
     "(" ++ String.intercalate " " (ts.map toString) ++ ")"
   | Forall n s t => s!"(forall (({quoteSymbol n} {s.toString})) {t.toString})"
+  | Exists n s t => s!"(exists (({quoteSymbol n} {s.toString})) {t.toString})"
   where
     arrowToList : Term → List Term
       | Arrow d c => d :: arrowToList c

--- a/Smt/Transformer.lean
+++ b/Smt/Transformer.lean
@@ -154,8 +154,7 @@ partial def markImps (e : Expr) : TransformerM Unit :=
 /-- Traverses `e` and marks quantified expressions over natural numbers for
     replacement with versions that ensure the quantified variables are greater
     than or equal to 0. For example, given `∀ x : Nat, p(x)`, this method
-    should mark the expr for replacement with `∀ x : Nat, x ≥ 0 → p(x)`.
-    TODO: Do something similar for `∃` when it gets supported. -/
+    should mark the expr for replacement with `∀ x : Nat, x ≥ 0 → p(x)`. -/
 partial def markNatForalls (e : Expr) : TransformerM Unit :=
   markImps' #[] e
   where

--- a/Smt/Util.lean
+++ b/Smt/Util.lean
@@ -70,6 +70,7 @@ def smtConsts : Std.HashSet String :=
     "not",
     "and",
     "or",
+    "exists",
     "=>",
     "Int",
     "+",

--- a/Test/Bool/Exists'.expected
+++ b/Test/Bool/Exists'.expected
@@ -1,7 +1,7 @@
-goal: ∃ p, true = true
+goal: ∃ p, p = true
 
 query:
-(assert (not (exists ((p Bool)) (= true true))))
+(assert (not (exists ((p Bool)) (= p true))))
 (check-sat)
 
 result: unsat

--- a/Test/Bool/Exists'.expected
+++ b/Test/Bool/Exists'.expected
@@ -1,0 +1,7 @@
+goal: ∃ p, true = true
+
+query:
+(assert (not (exists ((p Bool)) (= true true))))
+(check-sat)
+
+result: unsat

--- a/Test/Bool/Exists'.lean
+++ b/Test/Bool/Exists'.lean
@@ -1,0 +1,5 @@
+import Smt
+
+theorem exists' : ∃ (p : Bool), true := by
+  smt
+  exact Exists.intro true rfl

--- a/Test/Bool/Exists'.lean
+++ b/Test/Bool/Exists'.lean
@@ -1,5 +1,5 @@
 import Smt
 
-theorem exists' : ∃ (p : Bool), true := by
+theorem exists' : ∃ p : Bool, p := by
   smt
   exact Exists.intro true rfl

--- a/Test/Bool/Triv'''.lean
+++ b/Test/Bool/Triv'''.lean
@@ -1,7 +1,0 @@
-import Smt
-
-/-
-theorem test : ∃ (p : Bool), p := by
-  smt
-  exact Exists.intro True True.intro
--/

--- a/Test/Bool/Triv'.lean
+++ b/Test/Bool/Triv'.lean
@@ -1,6 +1,6 @@
 import Smt
 
-theorem triv': ∀ (p : Bool), ∀ _ : p, p := by
+theorem triv': ∀ p : Bool, ∀ _ : p, p := by
   smt
   intro p
   simp_all

--- a/Test/Int/ForallExists.expected
+++ b/Test/Int/ForallExists.expected
@@ -1,0 +1,8 @@
+goal: ∀ (x : Nat), ∃ y, Int.ofNat x ≤ y
+
+query:
+(define-sort Nat () Int)
+(assert (not (forall ((x Nat)) (=> (>= x 0) (exists ((y Int)) (<= x y))))))
+(check-sat)
+
+result: unsat

--- a/Test/Int/ForallExists.lean
+++ b/Test/Int/ForallExists.lean
@@ -1,0 +1,14 @@
+import Smt
+
+theorem forallExists : ∀ (x : Nat), ∃ (y : Int), x ≤ y := by
+  smt
+  intro x
+  apply Exists.intro
+  case w => exact Int.ofNat x
+  case h =>
+    induction x with
+    | zero => decide
+    | succ x ih =>
+        simp only [LE.le, Int.le, HSub.hSub, Sub.sub, Int.sub, Neg.neg,
+                   Int.neg, Int.negOfNat, HAdd.hAdd, Add.add, Int.add]
+        simp only [Int.subNatNat, Nat.sub_self, Int.NonNeg.mk]

--- a/Test/Int/ForallExists.lean
+++ b/Test/Int/ForallExists.lean
@@ -1,6 +1,6 @@
 import Smt
 
-theorem forallExists : ∀ (x : Nat), ∃ (y : Int), x ≤ y := by
+theorem forallExists : ∀ x : Nat, ∃ y : Int, x ≤ y := by
   smt
   intro x
   apply Exists.intro

--- a/Test/Nat/Exists''.expected
+++ b/Test/Nat/Exists''.expected
@@ -1,0 +1,8 @@
+goal: ∃ x, x ≥ 0
+
+query:
+(define-sort Nat () Int)
+(assert (not (exists ((x Nat)) (>= x 0))))
+(check-sat)
+
+result: unsat

--- a/Test/Nat/Exists''.lean
+++ b/Test/Nat/Exists''.lean
@@ -1,5 +1,5 @@
 import Smt
 
-theorem exists'' : ∃ (x : Nat), x ≥ 0 := by
+theorem exists'' : ∃ x : Nat, x ≥ 0 := by
   smt
   exact ⟨0, by decide⟩

--- a/Test/Nat/Exists''.lean
+++ b/Test/Nat/Exists''.lean
@@ -1,0 +1,5 @@
+import Smt
+
+theorem exists'' : ∃ (x : Nat), x ≥ 0 := by
+  smt
+  exact ⟨0, by decide⟩

--- a/Test/Nat/Exists'.expected
+++ b/Test/Nat/Exists'.expected
@@ -1,0 +1,7 @@
+goal: ∃ x, x = 1
+
+query:
+(assert (not (exists ((x Int)) (= x 1))))
+(check-sat)
+
+result: unsat

--- a/Test/Nat/Exists'.lean
+++ b/Test/Nat/Exists'.lean
@@ -1,0 +1,5 @@
+import Smt
+
+theorem exists' : ∃ (x : Int), x = 1 := by
+  smt
+  exact ⟨1, rfl⟩

--- a/Test/Nat/Exists'.lean
+++ b/Test/Nat/Exists'.lean
@@ -1,5 +1,5 @@
 import Smt
 
-theorem exists' : ∃ (x : Int), x = 1 := by
+theorem exists' : ∃ x : Int, x = 1 := by
   smt
   exact ⟨1, rfl⟩

--- a/Test/Nat/Exists.lean
+++ b/Test/Nat/Exists.lean
@@ -1,6 +1,0 @@
-import Smt
-
-/- theorem test : ∃ (x : Nat), x = 0 := by
-  smt
-  exact ⟨0, rfl⟩
--/

--- a/Test/Nat/Forall'.expected
+++ b/Test/Nat/Forall'.expected
@@ -1,0 +1,8 @@
+goal: ∀ (x : Nat), x ≥ 0
+
+query:
+(define-sort Nat () Int)
+(assert (not (forall ((x Nat)) (=> (>= x 0) (>= x 0)))))
+(check-sat)
+
+result: unsat

--- a/Test/Nat/Forall'.lean
+++ b/Test/Nat/Forall'.lean
@@ -1,0 +1,5 @@
+import Smt
+
+theorem forall' : ∀ x : Nat, x ≥ 0 := by
+  smt
+  simp [Nat.zero_le]

--- a/Test/Prop/Exists'.expected
+++ b/Test/Prop/Exists'.expected
@@ -1,0 +1,7 @@
+goal: ∃ p, p
+
+query:
+(assert (not (exists ((p Bool)) p)))
+(check-sat)
+
+result: unsat

--- a/Test/Prop/Exists'.lean
+++ b/Test/Prop/Exists'.lean
@@ -1,7 +1,5 @@
 import Smt
 
-/-
-theorem test : ∃ (p : Prop), p := by
+theorem exists' : ∃ (p : Prop), p := by
   smt
   exact Exists.intro True True.intro
--/

--- a/Test/Prop/Exists'.lean
+++ b/Test/Prop/Exists'.lean
@@ -1,5 +1,5 @@
 import Smt
 
-theorem exists' : ∃ (p : Prop), p := by
+theorem exists' : ∃ p : Prop, p := by
   smt
   exact Exists.intro True True.intro

--- a/Test/Prop/Triv'.lean
+++ b/Test/Prop/Triv'.lean
@@ -1,6 +1,6 @@
 import Smt
 
-theorem triv': ∀ (p : Prop), ∀ _ : p, p := by
+theorem triv': ∀ p : Prop, ∀ _ : p, p := by
   smt
   intro p
   simp_all


### PR DESCRIPTION
This PR adds `Exists` constructor to the Term data-structure (similar to `Forall`). It also adds support for conversion from `Nat` to `Int`.