### PR TITLE
Add initial support for strings.

### DIFF
--- a/Smt/Constants.lean
+++ b/Smt/Constants.lean
@@ -33,6 +33,8 @@ def knownConsts : Std.HashMap Expr (Option Expr) :=
     (mkConst `BEq.beq [levelZero], mkConst (Name.mkSimple "=")),
     (mkConst `Bool.true, mkConst `true),
     (mkConst `Bool.false, mkConst `false),
+    (mkConst `String.length, mkConst `str.len),
+    (mkConst `String.replace, mkConst `str.replace_all),
 
     (mkConst `Neg.neg [levelZero], mkConst (Name.mkSimple "-")),
     (mkConst `HAdd.hAdd levelsZero, mkConst (Name.mkSimple "+")),
@@ -50,7 +52,13 @@ def knownConsts : Std.HashMap Expr (Option Expr) :=
     (mkApp2 (mkConst `HDiv.hDiv levelsZero) (mkConst `Nat) (mkConst `Nat),
      mkConst `div),
     (mkApp2 (mkConst `HDiv.hDiv levelsZero) (mkConst `Int) (mkConst `Int),
-     mkConst `div)
+     mkConst `div),
+
+    (mkApp (mkConst `LT.lt [levelZero]) (mkConst `String),
+     mkConst (Name.mkSimple "str.<")),
+    ((mkApp2 (mkConst `HAppend.hAppend levelsZero)
+             (mkConst `String) (mkConst `String),
+     mkConst (Name.mkSimple "str.++")))
   ]
   where
     levelsZero := [levelZero, levelZero, levelZero]

--- a/Smt/Util.lean
+++ b/Smt/Util.lean
@@ -83,7 +83,15 @@ def smtConsts : Std.HashSet String :=
     ">",
     "<",
     ">=",
-    "<="
+    "<=",
+    "str.<",
+    "str.++",
+    "str.len",
+    "str.replace_all",
+    "str.at",
+    "str.contains",
+    "str.to_code",
+    "str.from_code"
   ]
 
 /-- Returns all unknown constants in the given expression. -/

--- a/Test/String/Append.expected
+++ b/Test/String/Append.expected
@@ -1,0 +1,7 @@
+goal: "a" ++ "b" = "ab"
+
+query:
+(assert (not (= (str.++ "a" "b") "ab")))
+(check-sat)
+
+result: unsat

--- a/Test/String/Append.lean
+++ b/Test/String/Append.lean
@@ -1,0 +1,5 @@
+import Smt
+
+theorem append : "a" ++ "b" = "ab" := by
+  smt
+  rfl

--- a/Test/String/Contains.expected
+++ b/Test/String/Contains.expected
@@ -1,0 +1,8 @@
+goal: String.contains "a" (Char.ofNat 97) = true
+
+query:
+(assert (not (= (str.contains "a" (str.from_code 97)) true)))
+(check-sat)
+
+result: unsat
+Test/String/Contains.lean:5:2: warning: declaration uses 'sorry'

--- a/Test/String/Contains.lean
+++ b/Test/String/Contains.lean
@@ -1,0 +1,5 @@
+import Smt
+
+theorem contains : "a".contains 'a' := by
+  smt
+  admit

--- a/Test/String/Empty.expected
+++ b/Test/String/Empty.expected
@@ -1,0 +1,7 @@
+goal: "" = ""
+
+query:
+(assert (not (= "" "")))
+(check-sat)
+
+result: unsat

--- a/Test/String/Empty.lean
+++ b/Test/String/Empty.lean
@@ -1,0 +1,5 @@
+import Smt
+
+theorem empty : "" = "" := by
+  smt
+  rfl

--- a/Test/String/GetOp.expected
+++ b/Test/String/GetOp.expected
@@ -1,0 +1,7 @@
+goal: String.getOp "a" 0 = Char.ofNat 97
+
+query:
+(assert (not (= (str.to_code (str.at "a" 0)) 97)))
+(check-sat)
+
+result: unsat

--- a/Test/String/GetOp.lean
+++ b/Test/String/GetOp.lean
@@ -1,0 +1,5 @@
+import Smt
+
+theorem index : "a"[0] = 'a' := by
+  smt
+  rfl

--- a/Test/String/Length.expected
+++ b/Test/String/Length.expected
@@ -1,0 +1,7 @@
+goal: String.length "a" = 1
+
+query:
+(assert (not (= (str.len "a") 1)))
+(check-sat)
+
+result: unsat

--- a/Test/String/Length.lean
+++ b/Test/String/Length.lean
@@ -1,0 +1,5 @@
+import Smt
+
+theorem length : "a".length = 1 := by
+  smt
+  rfl

--- a/Test/String/Lt.expected
+++ b/Test/String/Lt.expected
@@ -1,0 +1,7 @@
+goal: "a" < "b"
+
+query:
+(assert (not (str.< "a" "b")))
+(check-sat)
+
+result: unsat

--- a/Test/String/Lt.lean
+++ b/Test/String/Lt.lean
@@ -1,0 +1,5 @@
+import Smt
+
+theorem lt : "a" < "b" := by
+  smt
+  decide

--- a/Test/String/Replace.expected
+++ b/Test/String/Replace.expected
@@ -1,0 +1,8 @@
+goal: String.replace "a" "a" "b" = "b"
+
+query:
+(assert (not (= (str.replace_all "a" "a" "b") "b")))
+(check-sat)
+
+result: unsat
+Test/String/Replace.lean:5:2: warning: declaration uses 'sorry'

--- a/Test/String/Replace.lean
+++ b/Test/String/Replace.lean
@@ -1,0 +1,5 @@
+import Smt
+
+theorem replace : "a".replace "a" "b" = "b" := by
+  smt
+  admit


### PR DESCRIPTION
This PR adds initial support for strings functions. We face 3 problems when we generate queries for string theorems:
1. String theory in SMT-LIB does not support a character type. Those are converted into codepoints using `str.to_code` instead.
2. Not all string functions in Lean have an obvious corresponding function in SMT-LIB, and vice versa. For those, we need to be careful not introduce any soundness bug in the translation.
3. Many string functions in Lean are `partial`, so we cannot prove theorems that make use of them in Lean anyways.