### PR TITLE
Use attribute to mark transformers.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
     - name: Build lean-smt
       run: lake build
     - name: Test lean-smt
-      run: lake run test
+      run: lake script run test

--- a/Smt.lean
+++ b/Smt.lean
@@ -1,3 +1,7 @@
+import Smt.General
+import Smt.Nat
+import Smt.Prop
 import Smt.Solver
+import Smt.String
 import Smt.Tactic
 import Smt.Term

--- a/Smt/Attribute.lean
+++ b/Smt/Attribute.lean
@@ -1,0 +1,64 @@
+import Lean
+import Std
+
+namespace Smt.Attribute
+
+open Lean
+open Std
+
+/-- An extension to Lean's runtime environment to support SMT attributes.
+    Maintains a set of function declarations for the `smt` tactic to utilize
+    while generating the SMT query. -/
+abbrev SmtExtension := SimpleScopedEnvExtension Name (HashSet Name)
+
+/-- Adds a declaration to the set of function declarations maintained by the SMT
+    environment extension. -/
+def addSmtEntry (d : HashSet Name) (e : Name) : HashSet Name :=
+  d.insert e
+
+initialize smtExt : SmtExtension ← registerSimpleScopedEnvExtension {
+  name     := `SmtExt
+  initial  := {}
+  addEntry := addSmtEntry
+}
+
+/-- Throws unexpected type error. -/
+def throwUnexpectedType (t : Name) (n : Name) : AttrM Unit :=
+  throwError s!"unexpected type at '{n}', `{t}` expected"
+
+/-- Validates the tagged declaration. -/
+def validate (n : Name) : AttrM Unit := do
+  match (← getEnv).find? n with
+  | none      => throwError s!"unknown constant '{n}'"
+  | some info =>
+    match info.type with
+    | Expr.const c .. =>
+      if c != (`Smt.Transformer) then throwUnexpectedType `Smt.Transformer n
+    | _               => throwUnexpectedType `Smt.Transformer n
+
+/-- Registers an SMT attribute with the provided name and description and links
+    it against `ext`. -/
+def registerSmtAttr (attrName : Name) (attrDescr : String)
+  : IO Unit :=
+  registerBuiltinAttribute {
+    name  := attrName
+    descr := attrDescr
+    applicationTime := AttributeApplicationTime.afterTypeChecking
+    add   := fun decl stx attrKind => do
+      trace[Smt.debug.attr] s!"attrName: {attrName}, attrDescr: {attrDescr}"
+      trace[Smt.debug.attr] s!"decl: {decl}, stx: {stx}, attrKind: {attrKind}"
+      Attribute.Builtin.ensureNoArgs stx
+      validate decl
+      setEnv (smtExt.addEntry (← getEnv) decl)
+      trace[Smt.debug.attr]
+        s!"transformers: {(smtExt.getState (← getEnv)).toList}"
+    erase := fun declName => do
+      let s ← smtExt.getState (← getEnv)
+      let s ← s.erase declName
+      modifyEnv fun env => smtExt.modifyState env fun _ => s
+  }
+
+initialize registerSmtAttr `Smt
+             "Utilize this function to transform Lean expressions to SMT terms."
+
+end Smt.Attribute

--- a/Smt/Constants.lean
+++ b/Smt/Constants.lean
@@ -10,6 +10,10 @@ open Smt.Term
 open Smt.Solver
 open Lean
 
+infixl:20  " • " => App
+prefix:21 " ` " => Symbol
+prefix:21 " `` " => Literal
+
 def defNat (s : Solver) : Solver := defineSort s "Nat" [] (Symbol "Int")
 
 def defNatSub (s : Solver) : Solver :=

--- a/Smt/General.lean
+++ b/Smt/General.lean
@@ -1,0 +1,98 @@
+import Lean
+import Smt.Constants
+import Smt.Transformer
+
+namespace Smt.General
+
+open Lean
+open Lean.Expr
+open Smt.Constants
+open Smt.Transformer
+
+/-- Traverses `e` and marks type arguments in apps for removal. For example,
+    given `(App (App (App Eq Prop) p) q)`, this method should mark `Prop` for
+    removal and the resulting expr will be `(App (App Eq p) q)`. -/
+@[Smt] partial def markTypeArgs : Transformer := fun e => markTypeArgs' #[] e
+  where
+    markTypeArgs' xs e := do match e with
+      | app a@(app (const `Exists ..) ..) e d =>
+        markTypeArgs' xs a
+        markTypeArgs' xs e
+      | app f e d                             =>
+        markTypeArgs' xs f
+        if ← hasValidSort (e.instantiate xs) then markTypeArgs' xs e
+        else addMark e none
+      | lam n t b d                           =>
+        markTypeArgs' xs t
+        Meta.withLocalDecl n d.binderInfo t (λ x => markTypeArgs' (xs.push x) b)
+      | forallE n t b d                       =>
+        markTypeArgs' xs t
+        Meta.withLocalDecl n d.binderInfo t (λ x => markTypeArgs' (xs.push x) b)
+      | letE n t v b d                        =>
+        markTypeArgs' xs t
+        markTypeArgs' xs v
+        Meta.withLetDecl n t v (λ x => markTypeArgs' (xs.push x) b)
+      | mdata m e s                           => markTypeArgs' xs e
+      | proj s i e d                          => markTypeArgs' xs e
+      | e                                     => ()
+    -- Returns the whether or not we should add `e` to the argument list
+    -- (i.e., skip implicit sort arguments).
+    hasValidSort (e : Expr) : MetaM Bool := do
+      let type ← Meta.inferType e
+      match type with
+      | sort l ..  => l.isZero
+      | forallE .. => false    -- All arguments must be first order.
+      | _          => true
+
+/-- Traverses `e` and marks type class instantiations in apps for removal. For
+    example, given `(APP instOfNatNat (LIT 1))`, this method should mark
+    `instOfNatNat` for removal and the resulting expr will be `(LIT 1)`. -/
+@[Smt] partial def markInstArgs : Transformer := fun e => do match e with
+  | app f e d       =>
+    markInstArgs f
+    if ¬isInst e then markInstArgs e else addMark e none
+  | lam n t b d     => markInstArgs t; markInstArgs b
+  | forallE n t b d => markInstArgs t; markInstArgs b
+  | letE n t v b d  => markInstArgs t; markInstArgs v; markInstArgs b
+  | mdata m e s     => markInstArgs e
+  | proj s i e d    => markInstArgs e
+  | e               => if isInst e then addMark e none else ()
+  where
+    -- Checks whether `e` is a type class instantiation.
+    -- TODO: Too fragile, replace with better checks.
+    isInst (e : Expr) : Bool := 
+    match e with
+    | const n .. => "inst".isSubStrOf n.toString
+    | _          => false
+
+@[Smt] def markOfNat : Transformer := fun e => do match e with
+  | a@(app (const `Char.ofNat ..) e _)  =>
+    addMark a e
+    markOfNat e
+  | a@(app (const `Int.ofNat ..) e _)  =>
+    addMark a e
+    markOfNat e
+  | app f e _       => markOfNat f; markOfNat e
+  | lam _ _ b _     => markOfNat b
+  | mdata _ e _     => markOfNat e
+  | proj _ _ e _    => markOfNat e
+  | letE _ _ v b _  => markOfNat v; markOfNat b
+  | forallE _ t b _ => markOfNat t; markOfNat b
+  | _               => ()
+
+/-- Traverses `e` and marks Lean constants for replacement with corresponding
+    SMT-LIB versions. For example, given `"a" < "b"`, this method should mark
+    `<` for replacement with `str.<`. -/
+@[Smt] def markKnownConsts : Transformer := fun e => do
+  match knownConsts.find? e with
+  | some e' => addMark e e'
+  | none   => match e with
+    | app f e _       => markKnownConsts f; markKnownConsts e
+    | lam _ _ b _     => markKnownConsts b
+    | mdata _ e _     => markKnownConsts e
+    | proj _ _ e _    => markKnownConsts e
+    | letE _ _ v b _  => markKnownConsts v; markKnownConsts b
+    | forallE _ t b _ => markKnownConsts t; markKnownConsts b
+    | _               => ()
+
+end Smt.General

--- a/Smt/Nat.lean
+++ b/Smt/Nat.lean
@@ -1,0 +1,80 @@
+import Lean
+import Smt.Transformer
+
+namespace Smt.Nat
+
+open Lean
+open Lean.Expr
+open Smt.Transformer
+
+/-- Traverses `e` and marks type casts of literals to `Nat` for replacement with
+    just the literals. For example, given
+    `(app (app (app (OfNat.ofNat ..) ..) (LIT 0) ..) ..)`, this method should
+    mark the whole expr for replacement with just `(LIT 0)`. -/
+@[Smt] partial def markNatLiterals : Transformer := fun e => do match e with
+  | a@(app f e d)   => match toLiteral f with
+    | none   => markNatLiterals f; markNatLiterals e
+    | some l => addMark a l
+  | lam n t b d     => markNatLiterals t; markNatLiterals b
+  | forallE n t b d => markNatLiterals t; markNatLiterals b
+  | letE n t v b d  => markNatLiterals t; markNatLiterals v; markNatLiterals b
+  | mdata m e s     => markNatLiterals e
+  | proj s i e d    => markNatLiterals e
+  | e               => ()
+  where
+    toLiteral : Expr → Option Expr
+      | app (app (const n ..) ..) l .. => if n == `OfNat.ofNat then l else none
+      | e                              => none
+
+/-- Traverses `e` and marks `Nat` constructors `Nat.zero` and `Nat.succ n` for
+    replacement with `0` and `(+ n 1)`. -/
+@[Smt] partial def markNatCons : Transformer := fun e => do match e with
+  | a@(app (const `Nat.succ ..) e d) =>
+    markNatCons e
+    addMark a (plusOne e)
+  | app f e d                => markNatCons f; markNatCons e
+  | lam n t b d              => markNatCons t; markNatCons b
+  | forallE n t b d          => markNatCons t; markNatCons b
+  | letE n t v b d           => markNatCons t; markNatCons v; markNatCons b
+  | mdata m e s              => markNatCons e
+  | proj s i e d             => markNatCons e
+  | e@(const n ..)           => if n == `Nat.zero then
+                                  addMark e (mkLit (Literal.natVal 0))
+  | e                        => ()
+  where
+    plusOne e :=
+      mkApp2 (mkConst (Name.mkSimple "+")) e (mkLit (Literal.natVal 1))
+
+/-- Traverses `e` and marks quantified expressions over natural numbers for
+    replacement with versions that ensure the quantified variables are greater
+    than or equal to 0. For example, given `∀ x : Nat, p(x)`, this method
+    should mark the expr for replacement with `∀ x : Nat, x ≥ 0 → p(x)`. -/
+@[Smt] partial def markNatForalls : Transformer := fun e => markImps' #[] e
+  where
+    markImps' xs e := do match e with
+      | app f e d           => markImps' xs f; markImps' xs e
+      | lam n t b d         =>
+        markImps' xs t
+        Meta.withLocalDecl n d.binderInfo t (fun x => markImps' (xs.push x) b)
+      | e@(forallE n t@(const `Nat ..) b d) =>
+        markImps' xs t
+        if ¬(e.instantiate xs).isArrow then
+          addMark e (mkForall n d.binderInfo t (imp b))
+        Meta.withLocalDecl n d.binderInfo t (fun x => markImps' (xs.push x) b)
+      | e@(forallE n t b d) =>
+        markImps' xs t
+        Meta.withLocalDecl n d.binderInfo t (fun x => markImps' (xs.push x) b)
+      | letE n t v b d      =>
+        markImps' xs t
+        markImps' xs v
+        Meta.withLetDecl n t v (fun x => markImps' (xs.push x) b)
+      | mdata m e s         => markImps' xs e
+      | proj s i e d        => markImps' xs e
+      | e                   => ()
+    imp e := mkApp2 (mkConst (Name.mkSimple "=>"))
+                    (mkApp2 (mkConst (Name.mkSimple ">="))
+                            (mkBVar 0)
+                            (mkLit (Literal.natVal 0)))
+                    e
+
+end Smt.Nat

--- a/Smt/Prop.lean
+++ b/Smt/Prop.lean
@@ -1,0 +1,39 @@
+import Lean
+import Smt.Transformer
+
+namespace Smt.Prop
+
+open Lean
+open Lean.Expr
+open Smt.Transformer
+
+/-- Traverses `e` and marks arrows for replacement with `Imp`. For example,
+    given `(FORALL _ p q)`, this method should mark the given expr for
+    replacement with `(Imp p q)`. The replacement is done at this stage because
+    `e` is a well-typed Lean term. So, we can ask Lean to infer the type of `p`,
+    which is not possible after the pre-processing step. -/
+@[Smt] partial def markImps : Transformer := fun e => markImps' #[] e
+  where
+    markImps' xs e := do match e with
+      | app f e d           => markImps' xs f; markImps' xs e
+      | lam n t b d         =>
+        markImps' xs t;
+        Meta.withLocalDecl n d.binderInfo t (fun x => markImps' (xs.push x) b)
+      | e@(forallE n t b d) =>
+        markImps' xs t
+        let ti := t.instantiate xs
+        if (e.instantiate xs).isArrow ∧ (← Meta.inferType ti).isProp then
+          markImps' xs b
+          addMark e (mkApp2 imp t (b.lowerLooseBVars 1 1))
+        else
+          Meta.withLocalDecl n d.binderInfo t (fun x => markImps' (xs.push x) b)
+      | letE n t v b d      =>
+        markImps' xs t
+        markImps' xs v
+        Meta.withLetDecl n t v (fun x => markImps' (xs.push x) b)
+      | mdata m e s         => markImps' xs e
+      | proj s i e d        => markImps' xs e
+      | e                   => ()
+    imp := mkConst (Name.mkSimple "=>")
+
+end Smt.Prop

--- a/Smt/String.lean
+++ b/Smt/String.lean
@@ -1,0 +1,36 @@
+import Lean
+import Smt.Transformer
+
+namespace Smt.String
+
+open Lean
+open Lean.Expr
+open Smt.Transformer
+
+@[Smt] def markStringGetOp : Transformer := fun e => do match e with
+  | a@(app (app (const `String.getOp ..) f _) e _)  =>
+    addMark a (mkApp (mkConst `str.to_code) (mkApp2 (mkConst `str.at) f e))
+    markStringGetOp f
+    markStringGetOp e
+  | app f e _       => markStringGetOp f; markStringGetOp e
+  | lam _ _ b _     => markStringGetOp b
+  | mdata _ e _     => markStringGetOp e
+  | proj _ _ e _    => markStringGetOp e
+  | letE _ _ v b _  => markStringGetOp v; markStringGetOp b
+  | forallE _ t b _ => markStringGetOp t; markStringGetOp b
+  | _               => ()
+
+@[Smt] def markStringContains : Transformer := fun e => do match e with
+  | a@(app (app (const `String.contains ..) f _) e _)  =>
+    addMark a (mkApp2 (mkConst `str.contains) f (mkApp (mkConst `str.from_code) e))
+    markStringGetOp f
+    markStringGetOp e
+  | app f e _       => markStringContains f; markStringContains e
+  | lam _ _ b _     => markStringContains b
+  | mdata _ e _     => markStringContains e
+  | proj _ _ e _    => markStringContains e
+  | letE _ _ v b _  => markStringContains v; markStringContains b
+  | forallE _ t b _ => markStringContains t; markStringContains b
+  | _               => ()
+
+end Smt.String

--- a/Smt/Tactic.lean
+++ b/Smt/Tactic.lean
@@ -9,9 +9,10 @@ open Lean.Elab
 open Lean.Elab.Tactic
 
 initialize
-  Lean.registerTraceClass `Smt.debug
-  Lean.registerTraceClass `Smt.debug.query
-  Lean.registerTraceClass `Smt.debug.transformer
+  registerTraceClass `Smt.debug
+  registerTraceClass `Smt.debug.attr
+  registerTraceClass `Smt.debug.query
+  registerTraceClass `Smt.debug.transformer
 
 instance : Lean.KVMap.Value Kind where
   toDataValue

--- a/Smt/Term.lean
+++ b/Smt/Term.lean
@@ -12,10 +12,6 @@ inductive Term where
 
 namespace Term
 
-infixl:20  " • " => App
-prefix:21 " ` " => Symbol
-prefix:21 " `` " => Literal
-
 /-- SMT-LIBv2 quoting for symbols. -/
 def quoteSymbol (s : String) : String :=
   -- This is the set of SMT-LIBv2 permitted characters in "simple" (non-quoted)

--- a/Smt/Transformer.lean
+++ b/Smt/Transformer.lean
@@ -1,20 +1,25 @@
 import Lean
 import Smt.Term
 import Smt.Util
-import Smt.Constants
+import Smt.Attribute
 
-namespace Smt.Transformer
+namespace Smt
 
 open Lean
 open Lean.Expr
+open Smt.Attribute
 open Smt.Term
 open Smt.Util
-open Smt.Constants
 open Std
 
 /-- Monad for transforming expressions. Keeps track of sub-expressions marked
     for removal/replacement. -/
 abbrev TransformerM := StateT (HashMap Expr (Option Expr)) MetaM
+
+/-- Type of functions that mark expressions. -/
+abbrev Transformer := Expr → TransformerM Unit
+
+namespace Transformer
 
 /-- Mark `e` for removal (if `e'` is `none`) or replacement with `e'`. -/
 def addMark (e : Expr) (e' : Option Expr) : TransformerM Unit :=
@@ -28,232 +33,16 @@ def isMarked (e : Expr) : TransformerM Bool :=
 def getReplacement! (e : Expr) : TransformerM (Option Expr) :=
   get >>= fun map => map.find! e
 
-/-- Traverses `e` and marks type arguments in apps for removal. For example,
-    given `(App (App (App Eq Prop) p) q)`, this method should mark `Prop` for
-    removal and the resulting expr will be `(App (App Eq p) q)`. -/
-partial def markTypeArgs (e : Expr) : TransformerM Unit :=
-  markTypeArgs' #[] e
-  where
-    markTypeArgs' xs e := do match e with
-      | app a@(app (const `Exists ..) ..) e d =>
-        markTypeArgs' xs a
-        markTypeArgs' xs e
-      | app f e d                             =>
-        markTypeArgs' xs f
-        if ← hasValidSort (e.instantiate xs) then markTypeArgs' xs e
-        else addMark e none
-      | lam n t b d                           =>
-        markTypeArgs' xs t
-        Meta.withLocalDecl n d.binderInfo t (λ x => markTypeArgs' (xs.push x) b)
-      | forallE n t b d                       =>
-        markTypeArgs' xs t
-        Meta.withLocalDecl n d.binderInfo t (λ x => markTypeArgs' (xs.push x) b)
-      | letE n t v b d                        =>
-        markTypeArgs' xs t
-        markTypeArgs' xs v
-        Meta.withLetDecl n t v (λ x => markTypeArgs' (xs.push x) b)
-      | mdata m e s                           => markTypeArgs' xs e
-      | proj s i e d                          => markTypeArgs' xs e
-      | e                                     => ()
-    -- Returns the whether or not we should add `e` to the argument list
-    -- (i.e., skip implicit sort arguments).
-    hasValidSort (e : Expr) : MetaM Bool := do
-      let type ← Meta.inferType e
-      match type with
-      | sort l ..  => l.isZero
-      | forallE .. => false    -- All arguments must be first order.
-      | _          => true
-
-/-- Traverses `e` and marks type class instantiations in apps for removal. For
-    example, given `(APP instOfNatNat (LIT 1))`, this method should mark
-    `instOfNatNat` for removal and the resulting expr will be `(LIT 1)`. -/
-partial def markInstArgs (e : Expr) : TransformerM Unit := do match e with
-  | app f e d       =>
-    markInstArgs f
-    if ¬isInst e then markInstArgs e else addMark e none
-  | lam n t b d     => markInstArgs t; markInstArgs b
-  | forallE n t b d => markInstArgs t; markInstArgs b
-  | letE n t v b d  => markInstArgs t; markInstArgs v; markInstArgs b
-  | mdata m e s     => markInstArgs e
-  | proj s i e d    => markInstArgs e
-  | e               => if isInst e then addMark e none else ()
-  where
-    -- Checks whether `e` is a type class instantiation.
-    -- TODO: Too fragile, replace with better checks.
-    isInst (e : Expr) : Bool := 
-    match e with
-    | const n .. => "inst".isSubStrOf n.toString
-    | _          => false
-
-/-- Traverses `e` and marks `Nat` constructors `Nat.zero` and `Nat.succ n` for
-    replacement with `0` and `(+ n 1)`. -/
-partial def markNatCons (e : Expr) : TransformerM Unit :=
-  do match e with
-  | a@(app (const `Nat.succ ..) e d) =>
-    markNatCons e
-    addMark a (plusOne e)
-  | app f e d                => markNatCons f; markNatCons e
-  | lam n t b d              => markNatCons t; markNatCons b
-  | forallE n t b d          => markNatCons t; markNatCons b
-  | letE n t v b d           => markNatCons t; markNatCons v; markNatCons b
-  | mdata m e s              => markNatCons e
-  | proj s i e d             => markNatCons e
-  | e@(const n ..)           => if n == `Nat.zero then
-                                  addMark e (mkLit (Literal.natVal 0))
-  | e                        => ()
-  where
-    plusOne e :=
-      mkApp2 (mkConst (Name.mkSimple "+")) e (mkLit (Literal.natVal 1))
-
-/-- Traverses `e` and marks type casts of literals to `Nat` for replacement with
-    just the literals. For example, given
-    `(app (app (app (OfNat.ofNat ..) ..) (LIT 0) ..) ..)`, this method should
-    mark the whole expr for replacement with just `(LIT 0)`. -/
-partial def markNatLiterals (e : Expr) : TransformerM Unit :=
-  do match e with
-  | a@(app f e d)   => match toLiteral f with
-    | none   => markNatLiterals f; markNatLiterals e
-    | some l => addMark a l
-  | lam n t b d     => markNatLiterals t; markNatLiterals b
-  | forallE n t b d => markNatLiterals t; markNatLiterals b
-  | letE n t v b d  => markNatLiterals t; markNatLiterals v; markNatLiterals b
-  | mdata m e s     => markNatLiterals e
-  | proj s i e d    => markNatLiterals e
-  | e               => ()
-  where
-    toLiteral : Expr → Option Expr
-      | app (app (const n ..) ..) l .. => if n == `OfNat.ofNat then l else none
-      | e                              => none
-
-/-- Traverses `e` and marks arrows for replacement with `Imp`. For example,
-    given `(FORALL _ p q)`, this method should mark the given expr for
-    replacement with `(Imp p q)`. The replacement is done at this stage because
-    `e` is a well-typed Lean term. So, we can ask Lean to infer the type of `p`,
-    which is not possible after the pre-processing step. -/
-partial def markImps (e : Expr) : TransformerM Unit :=
-  markImps' #[] e
-  where
-    markImps' xs e := do match e with
-      | app f e d           => markImps' xs f; markImps' xs e
-      | lam n t b d         =>
-        markImps' xs t;
-        Meta.withLocalDecl n d.binderInfo t (fun x => markImps' (xs.push x) b)
-      | e@(forallE n t b d) =>
-        markImps' xs t
-        let ti := t.instantiate xs
-        if (e.instantiate xs).isArrow ∧ (← Meta.inferType ti).isProp then
-          markImps' xs b
-          addMark e (mkApp2 imp t (b.lowerLooseBVars 1 1))
-        else
-          Meta.withLocalDecl n d.binderInfo t (fun x => markImps' (xs.push x) b)
-      | letE n t v b d      =>
-        markImps' xs t
-        markImps' xs v
-        Meta.withLetDecl n t v (fun x => markImps' (xs.push x) b)
-      | mdata m e s         => markImps' xs e
-      | proj s i e d        => markImps' xs e
-      | e                   => ()
-    imp := mkConst (Name.mkSimple "=>")
-
-/-- Traverses `e` and marks quantified expressions over natural numbers for
-    replacement with versions that ensure the quantified variables are greater
-    than or equal to 0. For example, given `∀ x : Nat, p(x)`, this method
-    should mark the expr for replacement with `∀ x : Nat, x ≥ 0 → p(x)`. -/
-partial def markNatForalls (e : Expr) : TransformerM Unit :=
-  markImps' #[] e
-  where
-    markImps' xs e := do match e with
-      | app f e d           => markImps' xs f; markImps' xs e
-      | lam n t b d         =>
-        markImps' xs t
-        Meta.withLocalDecl n d.binderInfo t (fun x => markImps' (xs.push x) b)
-      | e@(forallE n t@(const `Nat ..) b d) =>
-        markImps' xs t
-        if ¬(e.instantiate xs).isArrow then
-          addMark e (mkForall n d.binderInfo t (imp b))
-        Meta.withLocalDecl n d.binderInfo t (fun x => markImps' (xs.push x) b)
-      | e@(forallE n t b d) =>
-        markImps' xs t
-        Meta.withLocalDecl n d.binderInfo t (fun x => markImps' (xs.push x) b)
-      | letE n t v b d      =>
-        markImps' xs t
-        markImps' xs v
-        Meta.withLetDecl n t v (fun x => markImps' (xs.push x) b)
-      | mdata m e s         => markImps' xs e
-      | proj s i e d        => markImps' xs e
-      | e                   => ()
-    imp e := mkApp2 (mkConst (Name.mkSimple "=>"))
-                    (mkApp2 (mkConst (Name.mkSimple ">="))
-                            (mkBVar 0)
-                            (mkLit (Literal.natVal 0)))
-                    e
-
-def markOfNat (e : Expr) : TransformerM Unit := do match e with
-  | a@(app (const `Char.ofNat ..) e _)  =>
-    addMark a e
-    markOfNat e
-  | a@(app (const `Int.ofNat ..) e _)  =>
-    addMark a e
-    markOfNat e
-  | app f e _       => markOfNat f; markOfNat e
-  | lam _ _ b _     => markOfNat b
-  | mdata _ e _     => markOfNat e
-  | proj _ _ e _    => markOfNat e
-  | letE _ _ v b _  => markOfNat v; markOfNat b
-  | forallE _ t b _ => markOfNat t; markOfNat b
-  | _               => ()
-
-def markStringGetOp (e : Expr) : TransformerM Unit := do match e with
-  | a@(app (app (const `String.getOp ..) f _) e _)  =>
-    addMark a (mkApp (mkConst `str.to_code) (mkApp2 (mkConst `str.at) f e))
-    markStringGetOp f
-    markStringGetOp e
-  | app f e _       => markStringGetOp f; markStringGetOp e
-  | lam _ _ b _     => markStringGetOp b
-  | mdata _ e _     => markStringGetOp e
-  | proj _ _ e _    => markStringGetOp e
-  | letE _ _ v b _  => markStringGetOp v; markStringGetOp b
-  | forallE _ t b _ => markStringGetOp t; markStringGetOp b
-  | _               => ()
-
-def markStringContains (e : Expr) : TransformerM Unit := do match e with
-  | a@(app (app (const `String.contains ..) f _) e _)  =>
-    addMark a (mkApp2 (mkConst `str.contains) f (mkApp (mkConst `str.from_code) e))
-    markStringGetOp f
-    markStringGetOp e
-  | app f e _       => markStringContains f; markStringContains e
-  | lam _ _ b _     => markStringContains b
-  | mdata _ e _     => markStringContains e
-  | proj _ _ e _    => markStringContains e
-  | letE _ _ v b _  => markStringContains v; markStringContains b
-  | forallE _ t b _ => markStringContains t; markStringContains b
-  | _               => ()
-
-/-- Traverses `e` and marks Lean constants for replacement with corresponding
-    SMT-LIB versions. For example, given `"a" < "b"`, this method should mark
-    `<` for replacement with `str.<`. -/
-def markKnownConsts (e : Expr) : TransformerM Unit := do
-  match knownConsts.find? e with
-  | some e' => addMark e e'
-  | none   => match e with
-    | app f e _       => markKnownConsts f; markKnownConsts e
-    | lam _ _ b _     => markKnownConsts b
-    | mdata _ e _     => markKnownConsts e
-    | proj _ _ e _    => markKnownConsts e
-    | letE _ _ v b _  => markKnownConsts v; markKnownConsts b
-    | forallE _ t b _ => markKnownConsts t; markKnownConsts b
-    | _               => ()
-
 /-- Traverses `e` and replaces marked sub-exprs with corresponding exprs in `es`
     or removes them if there are no corresponding exprs to replace them with.
     The order of the replacements is done in a top-down depth-first order. For
-    example, let that `e*` denote an expr `e` is marked for removal and `e*` denote `e` is marked for replacement with `e'`. Then given,
-    `(APP (APP a b*) c+)`, this method will return `(APP a c')`. Note that
-    this method also processes sub-exprs of `e'`. For example,
-    `(FORALL _ p+ q)+` is replaced with `(Imp p' q)`. Some replacements and
-    removals may return ill-formed exprs for SMT-LIBv2. It's the caller's
-    responsibility to ensure that the replacement do not produce ill-formed
-    exprs. -/
+    example, let that `e*` denote an expr `e` is marked for removal and `e*`
+    denote `e` is marked for replacement with `e'`. Then given,
+    `(APP (APP a b*) c+)`, this method will return `(APP a c')`. Note that this
+    method also processes sub-exprs of `e'`. For example, `(FORALL _ p+ q)+`
+    is replaced with `(Imp p' q)`. Some replacements and removals may return
+    ill-formed exprs for SMT-LIBv2. It's the caller's responsibility to ensure
+    that the replacement do not produce ill-formed exprs. -/
 partial def replaceMarked (e : Expr) : TransformerM (Option Expr) := do
   match ← isMarked e with
   | true => match ← getReplacement! e with
@@ -294,6 +83,22 @@ def List.toString (es : List (Expr × (Option Expr))) := s!"[" ++ String.interca
     helper : Expr × (Option Expr) → String
     | (e, o) => s!"({exprToString e},{o.format.pretty})"
 
+private unsafe def getTransformersUnsafe : MetaM (List Transformer) := do
+  let env ← getEnv
+  let names := (smtExt.getState env).toList
+  trace[Smt.debug.attr] "Transformers: {names}"
+  let mut transformers := []
+  for name in names do
+    let fn ← IO.ofExcept <| Id.run <| ExceptT.run <|
+      env.evalConst Transformer Options.empty name
+    transformers := fn :: transformers
+  transformers
+
+/-- Returns the list of transformers maintained by `smtExt` in the current
+    Lean environment. -/
+@[implementedBy getTransformersUnsafe]
+constant getTransformers : MetaM (List Transformer)
+
 /-- Pre-processes `e` and returns the resulting expr. -/
 def preprocessExpr (e : Expr) : MetaM Expr := do
   -- Print the `e` before the preprocessing step.
@@ -302,27 +107,14 @@ def preprocessExpr (e : Expr) : MetaM Expr := do
   -- Pass `e` through each pre-processing step to mark sub-exprs for removal or
   -- replacement. Note that each pass is passed the original expr `e` as an
   -- input. So, the order of the passes does not matter.
-  for pass in passes do
-    (_, es) ← (pass e).run es
+  for transformer in (← getTransformers) do
+    (_, es) ← (transformer e).run es
   -- Print the exprs marked for removal/replacement.
   trace[Smt.debug.transformer] "marked: {es.toList.toString}"
   -- Make the replacements and print the result.
   match ← (replaceMarked e).run es with
     | (none  , _) => panic! "Error: Something went wrong..."
     | (some e, _) => trace[Smt.debug.transformer] "After: {exprToString e}"; e
-  where
-    -- The passes to run through `e`.
-    passes : List (Expr → TransformerM Unit) :=
-    [markTypeArgs,
-     markInstArgs,
-     markNatCons,
-     markNatLiterals,
-     markImps,
-     markNatForalls,
-     markKnownConsts,
-     markOfNat,
-     markStringGetOp,
-     markStringContains]
 
 /-- Converts a Lean expression into an SMT term. -/
 partial def exprToTerm (e : Expr) : MetaM Term := do

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -22,7 +22,7 @@ partial def readAllFiles (dir : FilePath) : IO (Array FilePath) := do
 Run tests.
 
 USAGE:
-  lake run test
+  lake script run test
 
 Run tests.
 -/


### PR DESCRIPTION
This PR breaks down `Smt.Transformer` module into multiple ones (one for each theory). It introduces a new Lean attribute, `[smt]`, to track markers/transformers in those modules and retrieve them at run-time. More attributes will be added in the feature to modularize the system. This is also work towards refactoring `Smt.Transformer`.