### PR TITLE
chore: update tests

### DIFF
--- a/Test/Bool/Assoc.expected
+++ b/Test/Bool/Assoc.expected
@@ -9,4 +9,4 @@ query:
 (check-sat)
 
 result: sat
-Test/Bool/Assoc.lean:6:2: warning: declaration uses 'sorry'
+Test/Bool/Assoc.lean:3:8: warning: declaration uses 'sorry'

--- a/Test/Bool/Comm.expected
+++ b/Test/Bool/Comm.expected
@@ -8,4 +8,4 @@ query:
 (check-sat)
 
 result: sat
-Test/Bool/Comm.lean:5:2: warning: declaration uses 'sorry'
+Test/Bool/Comm.lean:3:8: warning: declaration uses 'sorry'

--- a/Test/Int/ForallExists.expected
+++ b/Test/Int/ForallExists.expected
@@ -6,4 +6,3 @@ query:
 (check-sat)
 
 result: unsat
-Test/Int/ForallExists.lean:11:13: warning: unused variable `ih`

--- a/Test/Int/ForallExists.expected
+++ b/Test/Int/ForallExists.expected
@@ -6,3 +6,4 @@ query:
 (check-sat)
 
 result: unsat
+Test/Int/ForallExists.lean:11:13: warning: unused variable `ih`

--- a/Test/Int/ForallExists.lean
+++ b/Test/Int/ForallExists.lean
@@ -8,7 +8,7 @@ theorem forallExists : ∀ x : Nat, ∃ y : Int, x ≤ y := by
   case h =>
     induction x with
     | zero => decide
-    | succ x ih =>
+    | succ x _ =>
         simp only [LE.le, Int.le, HSub.hSub, Sub.sub, Int.sub, Neg.neg,
                    Int.neg, Int.negOfNat, HAdd.hAdd, Add.add, Int.add]
         simp only [Int.subNatNat, Nat.sub_self, Int.NonNeg.mk]

--- a/Test/Nat/NeqZero.expected
+++ b/Test/Nat/NeqZero.expected
@@ -6,4 +6,4 @@ query:
 (check-sat)
 
 result: sat
-Test/Nat/NeqZero.lean:5:2: warning: declaration uses 'sorry'
+Test/Nat/NeqZero.lean:3:8: warning: declaration uses 'sorry'

--- a/Test/Prop/Assoc.expected
+++ b/Test/Prop/Assoc.expected
@@ -9,4 +9,4 @@ query:
 (check-sat)
 
 result: sat
-Test/Prop/Assoc.lean:6:2: warning: declaration uses 'sorry'
+Test/Prop/Assoc.lean:3:8: warning: declaration uses 'sorry'

--- a/Test/Prop/Comm.expected
+++ b/Test/Prop/Comm.expected
@@ -8,4 +8,4 @@ query:
 (check-sat)
 
 result: sat
-Test/Prop/Comm.lean:5:2: warning: declaration uses 'sorry'
+Test/Prop/Comm.lean:3:8: warning: declaration uses 'sorry'

--- a/Test/String/Contains.expected
+++ b/Test/String/Contains.expected
@@ -5,4 +5,4 @@ query:
 (check-sat)
 
 result: unsat
-Test/String/Contains.lean:5:2: warning: declaration uses 'sorry'
+Test/String/Contains.lean:3:8: warning: declaration uses 'sorry'

--- a/Test/String/Replace.expected
+++ b/Test/String/Replace.expected
@@ -5,4 +5,4 @@ query:
 (check-sat)
 
 result: unsat
-Test/String/Replace.lean:5:2: warning: declaration uses 'sorry'
+Test/String/Replace.lean:3:8: warning: declaration uses 'sorry'


### PR DESCRIPTION
It looks like warnings are now printed at the declaration name.