### PR TITLE
Interactive usage

### DIFF
--- a/Smt/Tactic/Smt.lean
+++ b/Smt/Tactic/Smt.lean
@@ -6,6 +6,8 @@ Authors: Abdalrhman Mohamed
 -/
 
 import Lean
+
+import Smt.Dsl.Sexp
 import Smt.Query
 import Smt.Solver
 
@@ -78,5 +80,13 @@ def parseTactic : Syntax → TacticM (List Expr)
   -- 5. Print the result.
   let res ← solver.checkSat kind path
   logInfo m!"goal: {goalType}\n\nquery:\n{query}\nresult: {res}"
+  let out ← match Sexp.parse res with
+    | .ok out => pure out
+    | .error e => throwError "cannot parse solver output: {e}"
+  if out.contains sexp!{sat} then
+    throwError "unable to prove goal, it is false"
+    -- TODO ask for countermodel and print
+  else if !out.contains sexp!{unsat} then
+    throwError "unable to prove goal"
 
 end Smt

--- a/Smt/Tactic/Smt.lean
+++ b/Smt/Tactic/Smt.lean
@@ -21,25 +21,6 @@ initialize
   registerTraceClass `smt.debug.query
   registerTraceClass `smt.debug.transformer
 
-instance : Lean.KVMap.Value Kind where
-  toDataValue
-    | Kind.cvc5 => "cvc5"
-    | Kind.z3   => "z3"
-  ofDataValue?
-    | "cvc5" => Kind.cvc5
-    | "z3" => Kind.z3
-    | _ => none
-
-register_option smt.solver.kind : Kind := {
-  defValue := Kind.cvc5
-  descr := "The solver to use for solving the SMT query."
-}
-
-register_option smt.solver.path : String := {
-  defValue := "cvc5"
-  descr := "The path to the solver used for the solving the SMT query."
-}
-
 /-- `smt` converts the current goal into an SMT query and checks if it is
 satisfiable. By default, `smt` generates the minimum valid SMT query needed to
 assert the current goal. However, that is not always enough:
@@ -93,7 +74,7 @@ def parseTactic : Syntax → TacticM (List Expr)
   let query := queryToString solver.commands
   -- 4. Run the solver.
   let kind := smt.solver.kind.get (← getOptions)
-  let path := smt.solver.path.get (← getOptions)
+  let path := smt.solver.path.get? (← getOptions) |>.getD (toString kind)
   -- 5. Print the result.
   let res ← solver.checkSat kind path
   logInfo m!"goal: {goalType}\n\nquery:\n{query}\nresult: {res}"

--- a/Test/Bool/Assoc.expected
+++ b/Test/Bool/Assoc.expected
@@ -9,4 +9,4 @@ query:
 (check-sat)
 
 result: sat
-Test/Bool/Assoc.lean:3:8: warning: declaration uses 'sorry'
+Test/Bool/Assoc.lean:5:2: error: unable to prove goal, it is false

--- a/Test/Bool/Comm.expected
+++ b/Test/Bool/Comm.expected
@@ -8,4 +8,4 @@ query:
 (check-sat)
 
 result: sat
-Test/Bool/Comm.lean:3:8: warning: declaration uses 'sorry'
+Test/Bool/Comm.lean:4:2: error: unable to prove goal, it is false

--- a/Test/Int/Dvd.expected
+++ b/Test/Int/Dvd.expected
@@ -1,0 +1,42 @@
+goal: dvd a c = true
+
+query:
+(declare-const a Int)
+(declare-const b Int)
+(declare-fun dvd (Int Int) Bool)
+(assert (= (dvd a b) true))
+(declare-const c Int)
+(assert (not (= (dvd a c) true)))
+(assert (= (dvd b c) true))
+(assert (forall ((x Int)) (forall ((y Int)) (forall ((z Int)) (=> (= (dvd x y) true) (=> (= (dvd y z) true) (= (dvd x z) true)))))))
+(check-sat)
+
+result: unsat
+goal: dvd c e = true
+
+query:
+(declare-const c Int)
+(declare-const d Int)
+(declare-fun dvd (Int Int) Bool)
+(assert (= (dvd c d) true))
+(declare-const e Int)
+(assert (= (dvd d e) true))
+(assert (not (= (dvd c e) true)))
+(assert (forall ((x Int)) (forall ((y Int)) (forall ((z Int)) (=> (= (dvd x y) true) (=> (= (dvd y z) true) (= (dvd x z) true)))))))
+(check-sat)
+
+result: unsat
+goal: dvd a e = true
+
+query:
+(declare-const c Int)
+(declare-const a Int)
+(declare-fun dvd (Int Int) Bool)
+(assert (= (dvd a c) true))
+(declare-const e Int)
+(assert (= (dvd c e) true))
+(assert (not (= (dvd a e) true)))
+(assert (forall ((x Int)) (forall ((y Int)) (forall ((z Int)) (=> (= (dvd x y) true) (=> (= (dvd y z) true) (= (dvd x z) true)))))))
+(check-sat)
+
+result: unsat

--- a/Test/Int/Dvd.lean
+++ b/Test/Int/Dvd.lean
@@ -1,0 +1,20 @@
+import Smt
+
+opaque dvd : Int → Int → Bool
+
+example
+    (a b c d e : Int)
+    (dvdax : ∀ x y z, dvd x y → dvd y z → dvd x z)
+    (h1 : dvd a b)
+    (h2 : dvd b c)
+    (h3 : dvd c d)
+    (h4 : dvd d e) :
+  dvd a e := by
+    have h5 : dvd a c := by
+      smt [h1, h2, dvdax]
+      exact dvdax _ _ _ h1 h2
+    have h6 : dvd c e := by
+      smt [h3, h4, dvdax]
+      exact dvdax _ _ _ h3 h4
+    smt [h5, h6, dvdax]
+    exact dvdax _ _ _ h5 h6

--- a/Test/Nat/Max.expected
+++ b/Test/Nat/Max.expected
@@ -12,6 +12,7 @@ query:
 (check-sat)
 
 result: unknown
+Test/Nat/Max.lean:12:2: error: unable to prove goal
 goal: x ≤ Max x y ∧ y ≤ Max x y
 
 query:

--- a/Test/Nat/NeqZero.expected
+++ b/Test/Nat/NeqZero.expected
@@ -6,4 +6,13 @@ query:
 (check-sat)
 
 result: sat
-Test/Nat/NeqZero.lean:3:8: warning: declaration uses 'sorry'
+Test/Nat/NeqZero.lean:4:2: error: unable to prove goal, it is false
+goal: ∀ (x : Nat), x + 1 ≠ 0
+
+query:
+(define-sort Nat () Int)
+(assert (not (forall ((x Nat)) (=> (>= x 0) (distinct (+ x 1) 0)))))
+(check-sat)
+
+result: unsat
+Test/Nat/NeqZero.lean:7:8: warning: declaration uses 'sorry'

--- a/Test/Nat/NeqZero.lean
+++ b/Test/Nat/NeqZero.lean
@@ -1,5 +1,9 @@
 import Smt
 
-theorem neq_zero : ∀ x, x ≠ 0 := by
+theorem neq_zero : ∀ (x : Nat), x ≠ 0 := by
+  smt
+  admit
+
+theorem succ_neq_zero : ∀ (x : Nat), x + 1 ≠ 0 := by
   smt
   admit

--- a/Test/Prop/Assoc.expected
+++ b/Test/Prop/Assoc.expected
@@ -9,4 +9,4 @@ query:
 (check-sat)
 
 result: sat
-Test/Prop/Assoc.lean:3:8: warning: declaration uses 'sorry'
+Test/Prop/Assoc.lean:5:2: error: unable to prove goal, it is false

--- a/Test/Prop/Comm.expected
+++ b/Test/Prop/Comm.expected
@@ -8,4 +8,4 @@ query:
 (check-sat)
 
 result: sat
-Test/Prop/Comm.lean:3:8: warning: declaration uses 'sorry'
+Test/Prop/Comm.lean:4:2: error: unable to prove goal, it is false

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -62,7 +62,7 @@ script test do
         env := #[("LEAN_PATH", path.toString)]
       }
       let expected ← IO.FS.readFile expected
-      if out.exitCode ≠ 0 ∨ ¬out.stderr.isEmpty ∨ out.stdout ≠ expected then
+      if ¬out.stderr.isEmpty ∨ out.stdout ≠ expected then
         IO.println s!"Failed: {test}"
         IO.println s!"Stderr:\n{out.stderr}"
         IO.println s!"Stdout:\n{out.stdout}"


### PR DESCRIPTION
- Closes #25.
- Show error when the solver fails to solve the goal. I did not add close-goal-with-sorry for now.
- Default `solver.path` to `solver.kind`, I was very confused as to why after setting the kind, CVC5 was still used.