### PR TITLE
Add support basic for recursive functions.

### DIFF
--- a/Smt/Nat.lean
+++ b/Smt/Nat.lean
@@ -15,6 +15,8 @@ open Smt.Transformer
 
 @[Smt] def replaceConst : Transformer
   | const `Nat.add ..  => pure (mkConst (Name.mkSimple "+"))
+  | const `Nat.mul ..  => pure (mkConst (Name.mkSimple "*"))
+  | const `Nat.div ..  => pure (mkConst (Name.mkSimple "div"))
   | const `Nat.le ..   => pure (mkConst (Name.mkSimple "<="))
   | app (app (const `GE.ge ..) (const `Nat ..) _) .. =>
     pure (mkConst (Name.mkSimple ">="))

--- a/Smt/Prop.lean
+++ b/Smt/Prop.lean
@@ -27,6 +27,13 @@ open Smt.Transformer
   | app (const `ite ..) ..    => pure (mkConst `ite)
   | e                         => pure e
 
+@[Smt] def replaceDecIte : Transformer
+  | app (app (app (const `ite ..) ..) e _) .. => do
+    return match ← applyTransformations e with
+    | none    => none
+    | some e' => some (mkApp (mkConst `ite) e')
+  | e                         => pure e
+
 /-- Replaces arrows with `Imp`. For example, given `(FORALL _ p q)`, this
     method returns `(Imp p q)`. The replacement is done at this stage because
     `e` is a well-typed Lean term. So, we can ask Lean to infer the type of `p`,

--- a/Smt/Query.lean
+++ b/Smt/Query.lean
@@ -102,6 +102,8 @@ partial def toDefineFun (s : Solver) (e : Expr) : MetaM Solver := do
   let d := eqnInfo.type
   let mutRecFuns := ConstantInfo.all (← getConstInfo e.constName!)
   trace[smt.debug.query] "mutually recursive functions with {e}: {mutRecFuns}"
+  -- TODO: Replace by `DefinitionVal.isRec` check when it gets added to Lean
+  -- core.
   if mutRecFuns.length > 1 then
     throwError "mutually recursive functions are not yet supported"
   if Util.countConst d e.constName! > 1 then
@@ -117,6 +119,9 @@ partial def toDefineFun (s : Solver) (e : Expr) : MetaM Solver := do
     type : Expr →  MetaM Term
       | forallE _ _ t _ => type t
       | t => Transformer.exprToTerm t
+    /-- Given an equation theorm of the form `∀ x₁ ⬝⬝⬝ xₙ, n x₁ ⬝⬝⬝ xₙ = body`,
+        this function instantiates all occurances of `x₁ ⬝⬝⬝ xₙ` in `body` and
+        converts the resulting `Expr` into an equivalent SMT `Term`.  -/
     body : Expr → MetaM Term
       | forallE n t b d                          =>
         Meta.withLocalDecl n d.binderInfo t (fun x => body (b.instantiate #[x]))

--- a/Smt/Query.lean
+++ b/Smt/Query.lean
@@ -6,10 +6,11 @@ Authors: Abdalrhman Mohamed, Tomaz Gomes Mascarenhas, Wojciech Nawrocki
 -/
 
 import Lean
+import Smt.Constants
 import Smt.Graph
 import Smt.Solver
 import Smt.Transformer
-import Smt.Constants
+import Smt.Util
 
 namespace Smt.Query
 
@@ -30,7 +31,7 @@ partial def buildDependencyGraph (g : Expr) (hs : List Expr) :
        StateT (Graph Expr Unit) MetaM Unit := do
       if (← get).contains e then
         return
-      assert!(e.isConst ∨ e.isFVar ∨ e.isMVar)
+      assert! e.isConst ∨ e.isFVar ∨ e.isMVar
       modify (·.addVertex e)
       if e.isConst then
         if e.constName! == `Nat then
@@ -93,22 +94,35 @@ def natConstAssert (n : String) (args : List Name) : Term → MetaM Term
       | [] => Symbol n
       | t :: ts => App (applyList n ts) (Symbol t.toString)
 
--- TODO: support recursive functions.
+-- TODO: support mutually recursive functions.
 partial def toDefineFun (s : Solver) (e : Expr) : MetaM Solver := do
-  let defn : Expr ← Meta.unfoldDefinition e
-  pure (defineFun s id (← params defn) (← type (← Meta.inferType defn)) (← body defn))
+  let some eqnThm ← getUnfoldEqnFor? (nonRec := true) e.constName!
+    | throwError "failed to retrieve equation theorem"
+  let eqnInfo ← getConstInfo eqnThm
+  let d := eqnInfo.type
+  let mutRecFuns := ConstantInfo.all (← getConstInfo e.constName!)
+  trace[smt.debug.query] "mutually recursive functions with {e}: {mutRecFuns}"
+  if mutRecFuns.length > 1 then
+    throwError "mutually recursive functions are not yet supported"
+  if Util.countConst d e.constName! > 1 then
+    pure (defineFunRec s id (← params d) (← type (← inferType e)) (← body d))
+  else
+    pure (defineFun s id (← params d) (← type (← inferType e)) (← body d))
   where
     id := if let const n .. := e then n.toString else panic! ""
     params : Expr → MetaM (List (String × Term))
-      | lam n t e _ => do
+      | forallE n t e _ => do
         return (n.toString, (← Transformer.exprToTerm t)) :: (← params e)
       | _ => pure []
     type : Expr →  MetaM Term
       | forallE _ _ t _ => type t
       | t => Transformer.exprToTerm t
     body : Expr → MetaM Term
-      | lam n t b d => Meta.withLocalDecl n d.binderInfo t (fun x => body (b.instantiate #[x]))
-      | e => do return ← Transformer.exprToTerm e
+      | forallE n t b d                          =>
+        Meta.withLocalDecl n d.binderInfo t (fun x => body (b.instantiate #[x]))
+      | app (app (app (const `Eq ..) ..) ..) e _ => Transformer.exprToTerm e
+      | e                                        =>
+        throwError "Error: unexpected equation theorem: {e}"
 
 partial def toDefineConst (s : Solver) (e : Expr) : MetaM Solver := do
   let defn : Expr ← Meta.unfoldDefinition e
@@ -137,9 +151,7 @@ def processVertex (hs : List Expr) (e : Expr) : StateT Solver MetaM Unit := do
   | fvar id .. => pure (← getLocalDecl id).userName.toString
   | const n .. => pure n.toString
   | _          => panic! ""
-  trace[smt.debug.query] "here1"
   let tt ← inferType t
-  trace[smt.debug.query] "here2"
   match tt with
     | sort l ..  => match l.toNat with
       | some 0 => solver := assert solver s

--- a/Smt/Util.lean
+++ b/Smt/Util.lean
@@ -70,7 +70,7 @@ def getMVars (e : Expr) : List Expr := (getMVars' e).eraseDups
 def hasMVars (e : Expr) : Bool := !(getMVars e).isEmpty
 
 /-- Count the number of occurances of the constant `c` in `e`. -/
-def Lean.Expr.countConst (e : Expr) (c : Name) : Nat :=
+def countConst (e : Expr) (c : Name) : Nat :=
   let rec visit : Expr → Nat
     | Expr.forallE _ d b _   => visit d + visit b
     | Expr.lam _ d b _       => visit d + visit b

--- a/Smt/Util.lean
+++ b/Smt/Util.lean
@@ -69,6 +69,19 @@ def getMVars (e : Expr) : List Expr := (getMVars' e).eraseDups
 /-- Does the expression `e` contain meta variables? -/
 def hasMVars (e : Expr) : Bool := !(getMVars e).isEmpty
 
+/-- Count the number of occurances of the constant `c` in `e`. -/
+def Lean.Expr.countConst (e : Expr) (c : Name) : Nat :=
+  let rec visit : Expr → Nat
+    | Expr.forallE _ d b _   => visit d + visit b
+    | Expr.lam _ d b _       => visit d + visit b
+    | Expr.mdata _ e _       => visit e
+    | Expr.letE _ t v b _    => visit t + visit v + visit b
+    | Expr.app f a _         => visit f + visit a
+    | Expr.proj _ _ e _      => visit e
+    | Expr.const c' _ _      => if c' == c then 1 else 0
+    | _                      => 0
+  visit e
+
 /-- Set of constants defined by SMT-LIB. -/
 def smtConsts : Std.HashSet String :=
   List.foldr (fun c s => s.insert c) Std.HashSet.empty

--- a/Test/Nat/Sum'.expected
+++ b/Test/Nat/Sum'.expected
@@ -1,0 +1,24 @@
+goal: sum Nat.zero = Nat.zero * (Nat.zero + 1) / 2
+
+query:
+(define-sort Nat () Int)
+(define-fun Nat.sub ((x Nat) (y Nat)) Nat (ite (< x y) 0 (- x y)))
+(define-fun-rec sum ((n Nat)) Nat (ite (= n 0) 0 (+ n (sum (Nat.sub n 1)))))
+(assert (not (= (sum 0) (div (* 0 (+ 0 1)) 2))))
+(check-sat)
+
+result: unsat
+goal: sum (Nat.succ n) = Nat.succ n * (Nat.succ n + 1) / 2
+
+query:
+(define-sort Nat () Int)
+(declare-const n Nat)
+(assert (>= n 0))
+(define-fun Nat.sub ((x Nat) (y Nat)) Nat (ite (< x y) 0 (- x y)))
+(define-fun-rec sum ((n Nat)) Nat (ite (= n 0) 0 (+ n (sum (Nat.sub n 1)))))
+(assert (not (= (sum (+ n 1)) (div (* (+ n 1) (+ (+ n 1) 1)) 2))))
+(assert (= (sum n) (div (* n (+ n 1)) 2)))
+(check-sat)
+
+result: unsat
+Test/Nat/Sum'.lean:5:8: warning: declaration uses 'sorry'

--- a/Test/Nat/Sum'.lean
+++ b/Test/Nat/Sum'.lean
@@ -1,0 +1,10 @@
+import Smt
+
+def sum (n : Nat) : Nat := if n = 0 then 0 else n + sum (n - 1)
+
+theorem sum_formula : sum n = n * (n + 1) / 2 := by
+  induction n with
+  | zero => smt [sum]; rfl
+  | succ n ih =>
+    smt [sum, ih]
+    sorry

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-06-21
+leanprover/lean4:nightly-2022-06-24


### PR DESCRIPTION
This PR adds support for basic recursive functions. Mutually recursive functions are not supported yet. We use `Meta.getUnfoldEqnFor?` instead of `Meta.unfoldDefinition?` because the latter returns the kernel's definition of functions. Since the kernel does not support recursive functions, `unfoldDefinition?` returns their definition in terms of general recursors and `WellFounded.fix`.  It's hard to recover the original definition from those compiled versions, so we use `Meta.getUnfoldEqnFor?` to get the user friendly version shown by the `unfold` tactic.