### PR TITLE
Usability improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build lean-smt
-      run: lake build
+      run: lake build Smt:shared
     - name: Test lean-smt
       run: lake script run test

--- a/Smt/Query.lean
+++ b/Smt/Query.lean
@@ -89,7 +89,7 @@ We expect `params` to contain enough free variables to make this a ground term. 
 Return the translated body, its dependencies, and whether the definition is recursive. -/
 def translateDefinitionBody (params : Array Expr) : Expr → QueryBuilderM (Term × Array Expr × Bool)
   | e@(fvar id ..) => do
-    let decl ← getLocalDecl id
+    let decl ← id.getDecl
     -- Look for an equational definition before defaulting to the let-body.
     let val ← getEqnDefLamFor? decl.userName
     let some val := val <|> decl.value?
@@ -160,7 +160,7 @@ def addCommandFor (e tp : Expr) : QueryBuilderM (Array Expr) := do
 
   -- Otherwise it is a local/global declaration with name `nm`.
   let nm ← match e with
-    | fvar id .. => pure (← getLocalDecl id).userName.toString
+    | fvar id .. => pure (← id.getDecl).userName.toString
     | const n .. => pure n.toString
     | _          => throwError "internal error, expected fvar or const but got{indentD e}\nof kind {e.ctorName}"
 
@@ -173,7 +173,7 @@ def addCommandFor (e tp : Expr) : QueryBuilderM (Array Expr) := do
 
   -- Filter out fvars introduced by the forall telescope. We cannot just ignore all fvars because
   -- the definition might depend on local bindings which we then have to translate.
-  deps.filterM (fun | fvar id .. => Option.isSome <$> findLocalDecl? id | _ => pure true)
+  deps.filterM (fun | fvar id .. => Option.isSome <$> id.findDecl? | _ => pure true)
 
 /-- Build a graph of SMT-LIB commands to emit with dependencies between them as edges. -/
 partial def buildDependencyGraph (g : Expr) : QueryBuilderM Unit := do

--- a/Smt/Solver.lean
+++ b/Smt/Solver.lean
@@ -11,24 +11,38 @@ import Smt.Term
 namespace Smt
 
 inductive Kind where
+  | cvc4
   | cvc5
   | z3
+  | yices
+  | boolector
   | vampire
-  deriving Inhabited
+  deriving Inhabited, DecidableEq
 
 instance : ToString Kind where
-  toString := fun
-    | .cvc5 => "cvc5"
-    | .z3 => "z3"
-    | .vampire => "vampire"
+  toString
+    | .cvc4      => "cvc4"
+    | .cvc5      => "cvc5"
+    | .z3        => "z3"
+    | .yices     => "yices"
+    | .boolector => "boolector"
+    | .vampire   => "vampire"
 
 instance : Lean.KVMap.Value Kind where
   toDataValue k := toString k
   ofDataValue?
-    | "cvc5"    => Kind.cvc5
-    | "z3"      => Kind.z3
-    | "vampire" => Kind.vampire
-    | _         => none
+    | "cvc4"      => Kind.cvc4
+    | "cvc5"      => Kind.cvc5
+    | "z3"        => Kind.z3
+    | "yices"     => Kind.yices
+    | "boolector" => Kind.boolector
+    | "vampire"   => Kind.vampire
+    | _           => none
+
+/-- What the binary for a given solver is usually called. -/
+def Kind.toDefaultPath : Kind → String
+  | .yices => "yices-smt2"
+  | k      => toString k
 
 register_option smt.solver.kind : Kind := {
   defValue := Kind.cvc5
@@ -99,25 +113,41 @@ def defineFunRec (id : String) (ps : List (String × Term)) (s : Term)
 def assert (t : Term) : Solver :=
   ⟨s!"(assert {t})" :: solver.commands⟩
 
+def queryToString : String :=
+  String.intercalate "\n" ("(check-sat)\n" :: solver.commands).reverse
+
 /-- Check if the query given so far is satisfiable and return the result. -/
-def checkSat (kind : Kind) (path : String) : IO String := do
+def checkSat (kind : Kind) (path : String) (timeoutSecs? : Option Nat := some 5) : IO String := do
+  let mut args := match kind with
+    | .cvc4      => #["--quiet", "--lang", "smt"]
+    | .cvc5      => #["--quiet", "--lang", "smt"]
+    | .z3        => #["-in", "-smt2"]
+    | .yices     => #[]
+    | .boolector => #["--smt2"]
+    | .vampire   => #["--input_syntax", "smtlib2", "--output_mode", "smtcomp"]
+  if let some secs := timeoutSecs? then
+    args := args ++ match kind with
+    | .cvc4      => #["--tlimit", toString (secs*1000)]
+    | .cvc5      => #["--tlimit", toString (secs*1000)]
+    | .z3        => #[s!"-T:{secs}"]
+    | .yices     => #["--timeout", toString secs]
+    | .boolector => #["--time", toString secs]
+    | .vampire   => #["--time_limit", toString secs]
   let proc ← IO.Process.spawn {
     stdin := IO.Process.Stdio.piped
     stdout := IO.Process.Stdio.piped
     stderr := IO.Process.Stdio.piped
     cmd := path
-    args := match kind with
-      | Kind.cvc5    => #["-q"]
-      | Kind.z3      => #["-in"]
-      | Kind.vampire => #["--input_syntax", "smtlib2", "--output_mode", "smtcomp"]
+    args
   }
-  let query := String.intercalate
-                 "\n" ("(exit)\n" :: "(check-sat)" :: solver.commands).reverse
+  let query := solver.queryToString ++ "\n(exit)"
   proc.stdin.putStr query
   -- Close stdin to signal EOF to the solver.
   let (_, proc) ← proc.takeStdin
   _ ← proc.wait
-  proc.stdout.readToEnd
+  let out ← proc.stdout.readToEnd
+  let err ← proc.stderr.readToEnd
+  return s!"{out}{if err.isEmpty then "" else "\n"}{err}"
 
 end Solver
 end Smt

--- a/Smt/Tactic/EqnDef.lean
+++ b/Smt/Tactic/EqnDef.lean
@@ -87,7 +87,7 @@ def addEqnDefForConst (nm : Name) : TacticM FVarId := do
       return (eqAbstracted, pfAbstracted)
 
   liftMetaTacticAux fun mvarId => do
-    let (fv, mvarId) ← intro1P (← assert mvarId (nm ++ `def) eqn pf)
+    let (fv, mvarId) ← (← mvarId.assert (nm ++ `def) eqn pf).intro1P
     return (fv, [mvarId])
 
 /-- Given `e : tp`, make a local constant `$nm : tp := e` and add an equational definition
@@ -102,7 +102,7 @@ def addEqnDefWithBody (nm : Name) (e : Expr) : TacticM (FVarId × FVarId) := do
     -- TODO: We have to `define` in order for the proofs to go through, but ideally
     -- we would hide the actual `let` body in the goal state as it's already shown
     -- in the equational definition.
-    let (fvVar, mvarId) ← intro1P (← define mvarId nm tp e)
+    let (fvVar, mvarId) ← (← mvarId.define nm tp e).intro1P
     return (fvVar, [mvarId])
   
   let (eqn, pf) ← withMainContext <| lambdaTelescope e fun args body => do
@@ -116,7 +116,7 @@ def addEqnDefWithBody (nm : Name) (e : Expr) : TacticM (FVarId × FVarId) := do
     return (eqAbstracted, pfAbstracted)
 
   liftMetaTacticAux fun mvarId => do
-    let (fvEq, mvarId) ← intro1P (← assert mvarId (nm ++ `def) eqn pf)
+    let (fvEq, mvarId) ← (← mvarId.assert (nm ++ `def) eqn pf).intro1P
     return ((fvVar, fvEq), [mvarId])
 
 end Smt

--- a/Smt/Tactic/Smt.lean
+++ b/Smt/Tactic/Smt.lean
@@ -23,6 +23,8 @@ initialize
   registerTraceClass `smt.debug.query
   registerTraceClass `smt.debug.translator
 
+syntax smtHints := optional("[" ident,* "]")
+
 /-- `smt` converts the current goal into an SMT query and checks if it is
 satisfiable. By default, `smt` generates the minimum valid SMT query needed to
 assert the current goal. However, that is not always enough:
@@ -52,33 +54,42 @@ The tactic then generates the query below:
 (check-sat)
 ```
 -/
-syntax (name := smt) "smt" ("[" ident,* "]")? : tactic
+syntax (name := smt) "smt" smtHints : tactic
+
+/-- Like `smt`, but just shows the query without invoking a solver. -/
+syntax (name := smtShow) "smt_show" smtHints : tactic
 
 def queryToString (commands : List String) : String :=
   String.intercalate "\n" ("(check-sat)\n" :: commands).reverse
 
-def parseTactic : Syntax → TacticM (List Expr)
-  | `(tactic| smt)              => pure []
-  | `(tactic| smt [ $[$hs],* ]) => hs.toList.mapM (fun h => elabTerm h.raw none)
-  | _                           => throwUnsupportedSyntax
+def parseHints : TSyntax `smtHints → TacticM (List Expr)
+  | `(smtHints| [ $[$hs],* ]) => hs.toList.mapM (fun h => elabTerm h.raw none)
+  | `(smtHints| ) => return []
+  | _ => throwUnsupportedSyntax
 
-@[tactic smt] def evalSmt : Tactic := fun stx => withMainContext do
+def prepareSmtQuery (hints : TSyntax `smtHints) : TacticM Solver := do
   -- 1. Get the current main goal.
   let goalType ← Tactic.getMainTarget
   let goalId ← Lean.mkFreshMVarId
   Lean.Meta.withLocalDeclD goalId.name (mkNot goalType) fun g => do
   -- 2. Get the hints passed to the tactic.
-  let mut hs ← parseTactic stx
+  let mut hs ← parseHints hints
   hs := hs.eraseDups
   -- 3. Generate the SMT query.
   let mut solver := Solver.mk []
-  solver ← Query.generateQuery g hs solver
+  Query.generateQuery g hs solver
+
+@[tactic smt] def evalSmt : Tactic := fun stx => withMainContext do
+  let goalType ← Tactic.getMainTarget
+  let solver ← prepareSmtQuery ⟨stx[1]⟩
   let query := queryToString solver.commands
   -- 4. Run the solver.
   let kind := smt.solver.kind.get (← getOptions)
   let path := smt.solver.path.get? (← getOptions) |>.getD (toString kind)
-  -- 5. Print the result.
+  -- Don't run solver if the server cancelled our task
+  if (← IO.checkCanceled) then return
   let res ← solver.checkSat kind path
+  -- 5. Print the result.
   logInfo m!"goal: {goalType}\n\nquery:\n{query}\nresult: {res}"
   let out ← match Sexp.parse res with
     | .ok out => pure out
@@ -88,5 +99,12 @@ def parseTactic : Syntax → TacticM (List Expr)
     -- TODO ask for countermodel and print
   else if !out.contains sexp!{unsat} then
     throwError "unable to prove goal"
+
+@[tactic smtShow] def evalSmtShow : Tactic := fun stx => withMainContext do
+  let goalType ← Tactic.getMainTarget
+  let solver ← prepareSmtQuery ⟨stx[1]⟩
+  let query := queryToString solver.commands
+  -- 4. Print the query.
+  logInfo m!"goal: {goalType}\n\nquery:\n{query}"
 
 end Smt

--- a/Smt/Term.lean
+++ b/Smt/Term.lean
@@ -61,16 +61,16 @@ def quoteSymbol (s : String) : String :=
   else s
 
 /-- Print given `Term` in SMT-LIBv2 format. -/
-partial def toString : Term → String
+protected partial def toString : Term → String
   | literalT l    => l             -- do not quote theory literals
   | symbolT n     => quoteSymbol n
   | t@(arrowT ..) =>
     let ss := arrowToList t
-    "(" ++ String.intercalate " " (ss.init.map toString) ++ ") "
+    "(" ++ String.intercalate " " (ss.init.map Term.toString) ++ ") "
         ++ ss.getLast!.toString
   | t@(appT ..) =>
     let ts := List.reverse <| appToList t
-    "(" ++ String.intercalate " " (ts.map toString) ++ ")"
+    "(" ++ String.intercalate " " (ts.map Term.toString) ++ ")"
   | forallT n s t => s!"(forall (({quoteSymbol n} {s.toString})) {t.toString})"
   | existsT n s t => s!"(exists (({quoteSymbol n} {s.toString})) {t.toString})"
   | letT n t b    => s!"(let (({quoteSymbol n} {t.toString})) {b.toString})"
@@ -83,7 +83,7 @@ partial def toString : Term → String
       | s        => [s]
 
 instance : ToString Term where
-  toString := toString
+  toString := Term.toString
 
 instance : Std.ToFormat Term where
   format := Std.Format.text ∘ toString

--- a/Test/Int/Dvd.expected
+++ b/Test/Int/Dvd.expected
@@ -1,42 +1,42 @@
 goal: dvd a c = true
 
 query:
+(declare-const a Int)
 (declare-const b Int)
-(declare-const c Int)
 (declare-fun dvd (Int Int) Bool)
+(assert (= (dvd a b) true))
+(declare-const c Int)
+(assert (not (= (dvd a c) true)))
 (assert (= (dvd b c) true))
 (assert (forall ((x Int)) (forall ((y Int)) (forall ((z Int)) (=> (= (dvd x y) true) (=> (= (dvd y z) true) (= (dvd x z) true)))))))
-(declare-const a Int)
-(assert (= (dvd a b) true))
-(assert (not (= (dvd a c) true)))
 (check-sat)
 
 result: unsat
 goal: dvd c e = true
 
 query:
+(declare-const c Int)
 (declare-const d Int)
-(declare-const e Int)
 (declare-fun dvd (Int Int) Bool)
+(assert (= (dvd c d) true))
+(declare-const e Int)
+(assert (not (= (dvd c e) true)))
 (assert (= (dvd d e) true))
 (assert (forall ((x Int)) (forall ((y Int)) (forall ((z Int)) (=> (= (dvd x y) true) (=> (= (dvd y z) true) (= (dvd x z) true)))))))
-(declare-const c Int)
-(assert (= (dvd c d) true))
-(assert (not (= (dvd c e) true)))
 (check-sat)
 
 result: unsat
 goal: dvd a e = true
 
 query:
-(declare-const a Int)
+(declare-const c Int)
 (declare-const e Int)
 (declare-fun dvd (Int Int) Bool)
+(assert (= (dvd c e) true))
+(declare-const a Int)
+(assert (= (dvd a c) true))
 (assert (not (= (dvd a e) true)))
 (assert (forall ((x Int)) (forall ((y Int)) (forall ((z Int)) (=> (= (dvd x y) true) (=> (= (dvd y z) true) (= (dvd x z) true)))))))
-(declare-const c Int)
-(assert (= (dvd c e) true))
-(assert (= (dvd a c) true))
 (check-sat)
 
 result: unsat

--- a/Test/Int/DvdTimeout.expected
+++ b/Test/Int/DvdTimeout.expected
@@ -1,0 +1,19 @@
+goal: dvd a (b + c + d) = true
+
+query:
+(set-logic UFLIA)
+(declare-fun dvd (Int Int) Bool)
+(assert (forall ((x Int)) (forall ((y Int)) (forall ((z Int)) (=> (= (dvd x y) true) (=> (= (dvd x z) true) (= (dvd x (+ y z)) true)))))))
+(declare-const c Int)
+(declare-const a Int)
+(assert (= (dvd a c) true))
+(declare-const d Int)
+(declare-const b Int)
+(assert (not (= (dvd a (+ (+ b c) d)) true)))
+(assert (= (dvd a b) true))
+(assert (= (dvd a d) true))
+(check-sat)
+
+result: 
+cvc5 interrupted by timeout.
+Test/Int/DvdTimeout.lean:13:4: error: unable to prove goal

--- a/Test/Int/DvdTimeout.expected
+++ b/Test/Int/DvdTimeout.expected
@@ -1,7 +1,6 @@
 goal: dvd a (b + c + d) = true
 
 query:
-(set-logic UFLIA)
 (declare-fun dvd (Int Int) Bool)
 (assert (forall ((x Int)) (forall ((y Int)) (forall ((z Int)) (=> (= (dvd x y) true) (=> (= (dvd x z) true) (= (dvd x (+ y z)) true)))))))
 (declare-const c Int)

--- a/Test/Int/DvdTimeout.lean
+++ b/Test/Int/DvdTimeout.lean
@@ -1,0 +1,13 @@
+import Smt
+
+opaque dvd : Int → Int → Bool
+
+-- https://github.com/cvc5/cvc5/issues/8848
+example
+    (a b c d : Int)
+    (dvdax : ∀ x y z, dvd x y → dvd x z → dvd x (y + z))
+    (h1 : dvd a b)
+    (h2 : dvd a c)
+    (h3 : dvd a d)
+  : dvd a (b + c + d) := by
+    smt [dvdax, h1, h2, h3] (timeout := 1)

--- a/Test/Nat/Max.expected
+++ b/Test/Nat/Max.expected
@@ -22,7 +22,7 @@ query:
 (declare-const y Nat)
 (assert (>= y 0))
 (define-fun Max ((x Nat) (y Nat)) Nat (ite (<= x y) y x))
-(assert (forall ((_uniq.235 Nat)) (=> (>= _uniq.235 0) (forall ((_uniq.236 Nat)) (=> (>= _uniq.236 0) (>= (Max _uniq.235 _uniq.236) 0))))))
+(assert (forall ((_uniq.236 Nat)) (=> (>= _uniq.236 0) (forall ((_uniq.237 Nat)) (=> (>= _uniq.237 0) (>= (Max _uniq.236 _uniq.237) 0))))))
 (assert (not (and (<= x (Max x y)) (<= y (Max x y)))))
 (check-sat)
 

--- a/Test/Nat/Sum'.expected
+++ b/Test/Nat/Sum'.expected
@@ -3,9 +3,9 @@ goal: sum Nat.zero = Nat.zero * (Nat.zero + 1) / 2
 query:
 (define-sort Nat () Int)
 (define-fun Nat.sub ((x Nat) (y Nat)) Nat (ite (< x y) 0 (- x y)))
-(assert (forall ((_uniq.3845 Nat)) (=> (>= _uniq.3845 0) (forall ((_uniq.3846 Nat)) (=> (>= _uniq.3846 0) (>= (Nat.sub _uniq.3845 _uniq.3846) 0))))))
+(assert (forall ((_uniq.5294 Nat)) (=> (>= _uniq.5294 0) (forall ((_uniq.5295 Nat)) (=> (>= _uniq.5295 0) (>= (Nat.sub _uniq.5294 _uniq.5295) 0))))))
 (define-fun-rec sum ((n Nat)) Nat (ite (= n 0) 0 (+ n (sum (Nat.sub n 1)))))
-(assert (forall ((_uniq.3847 Nat)) (=> (>= _uniq.3847 0) (>= (sum _uniq.3847) 0))))
+(assert (forall ((_uniq.5296 Nat)) (=> (>= _uniq.5296 0) (>= (sum _uniq.5296) 0))))
 (assert (not (= (sum 0) (div (* 0 (+ 0 1)) 2))))
 (check-sat)
 
@@ -17,9 +17,9 @@ query:
 (declare-const n Nat)
 (assert (>= n 0))
 (define-fun Nat.sub ((x Nat) (y Nat)) Nat (ite (< x y) 0 (- x y)))
-(assert (forall ((_uniq.3861 Nat)) (=> (>= _uniq.3861 0) (forall ((_uniq.3862 Nat)) (=> (>= _uniq.3862 0) (>= (Nat.sub _uniq.3861 _uniq.3862) 0))))))
+(assert (forall ((_uniq.5310 Nat)) (=> (>= _uniq.5310 0) (forall ((_uniq.5311 Nat)) (=> (>= _uniq.5311 0) (>= (Nat.sub _uniq.5310 _uniq.5311) 0))))))
 (define-fun-rec sum ((n Nat)) Nat (ite (= n 0) 0 (+ n (sum (Nat.sub n 1)))))
-(assert (forall ((_uniq.3863 Nat)) (=> (>= _uniq.3863 0) (>= (sum _uniq.3863) 0))))
+(assert (forall ((_uniq.5312 Nat)) (=> (>= _uniq.5312 0) (>= (sum _uniq.5312) 0))))
 (assert (not (= (sum (+ n 1)) (div (* (+ n 1) (+ (+ n 1) 1)) 2))))
 (assert (= (sum n) (div (* n (+ n 1)) 2)))
 (check-sat)

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,7 +2,8 @@ import Lake
 
 open Lake DSL
 
-package smt
+package smt where
+  precompileModules := true
 
 @[defaultTarget]
 lean_lib Smt

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -29,9 +29,7 @@ USAGE:
 Run tests.
 -/
 script test do
-  let lean := match (← Lake.findLeanInstall?) with
-    | none   => panic! "Error: could not find lean executable."
-    | some i => i.lean
+  let lean ← getLean
   let files ← readAllFiles (FilePath.mk "Test")
   let mut tests : Array FilePath := #[]
   let mut expected : Array FilePath := #[]
@@ -44,7 +42,7 @@ script test do
   for t in tests do
     let e := t.withExtension "expected"
     if (expected.contains e) then
-      tasks := (← IO.asTask (runTest lean t e)) :: tasks
+      tasks := (← IO.asTask (runTest lean t e (← readThe Lake.Context))) :: tasks
     else
       IO.println s!"Error: Could not find {e}"
       return 1
@@ -54,13 +52,16 @@ script test do
       return code
   return 0
   where
-    runTest (lean : FilePath) (test : FilePath) (expected : FilePath) : IO UInt32 := do
-      let path :=  Lake.defaultBuildDir.join Lake.defaultOleanDir.toString
+    runTest (lean : FilePath) (test : FilePath) (expected : FilePath) : ScriptM UInt32 := do
       IO.println s!"Start : {test}"
+      let leanPath ← getAugmentedLeanPath
+      -- Note: this only works on Unix since it needs the shared library `libSmt`
+      -- to also load its transitive dependencies.
+      let dynlib := (← findModule? `Smt).get!.dynlibFile
       let out ← IO.Process.output {
         cmd := lean.toString
-        args := #[test.toString],
-        env := #[("LEAN_PATH", path.toString)]
+        args := #[s!"--load-dynlib={dynlib}", test.toString],
+        env := #[("LEAN_PATH", leanPath.toString)]
       }
       let expected ← IO.FS.readFile expected
       if ¬out.stderr.isEmpty ∨ out.stdout ≠ expected then

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-07-14
+leanprover/lean4:nightly-2022-07-29


### PR DESCRIPTION
- Add `smt_show` tactic which just shows the query but does not run a solver.
- Support setting a solving timeout.
- Default to a 5s timeout since it is too easy for unsuspecting users to blow up their machine with a heavy query.