### PR TITLE
Refactor the Solver data-structure into a monad.

### DIFF
--- a/Smt/Commands.lean
+++ b/Smt/Commands.lean
@@ -48,7 +48,7 @@ protected def toSexp : Command → Sexp
     sexp!{(declare-fun {quoteSymbol nm} (...{sts.init.map toSexp}) {sts.getLast!})}
   | .declare nm st                => sexp!{(declare-const {quoteSymbol nm} {st})}
   | .declareSort nm arity         =>
-    sexp!{(declare-sort {quoteSymbol nm} {String.mk (Nat.toDigits 10 arity)})}
+    sexp!{(declare-sort {quoteSymbol nm} {toString arity})}
   | .defineSort nm ps tm          =>
     sexp!{(define-sort {quoteSymbol nm} (...{ps.map toSexp}) {tm})}
   | .defineFun nm ps cod tm false =>

--- a/Smt/Commands.lean
+++ b/Smt/Commands.lean
@@ -51,8 +51,6 @@ protected def toSexp : Command → Sexp
     sexp!{(declare-sort {quoteSymbol nm} {String.mk (Nat.toDigits 10 arity)})}
   | .defineSort nm ps tm          =>
     sexp!{(define-sort {quoteSymbol nm} (...{ps.map toSexp}) {tm})}
-  | .defineFun nm [] cod tm _     =>
-    sexp!{(define-const {quoteSymbol nm} {cod} { tm})}
   | .defineFun nm ps cod tm false =>
     sexp!{(define-fun {quoteSymbol nm} {paramsToSexp ps} {cod} {tm})}
   | .defineFun nm ps cod tm true  =>

--- a/Smt/Commands.lean
+++ b/Smt/Commands.lean
@@ -5,18 +5,25 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed, Tomaz Gomes Mascarenhas, Wojciech Nawrocki
 -/
 
-import Smt.Solver
+import Smt.Data.Sexp
+import Smt.Dsl.Sexp
 import Smt.Term
 
 namespace Smt
+open Smt
 
 /-- An SMT-LIBv2 command that we can emit. -/
 inductive Command where
-  | assert (tm : Term)
-  | declare (nm : String) (st : Term)
+  | setLogic (l : String)
+  | setOption (k : String) (v : String)
   | declareSort (nm : String) (arity : Nat)
   | defineSort (nm : String) (ps : List Term) (tm : Term)
+  | declare (nm : String) (st : Term)
   | defineFun (nm : String) (ps : List (String × Term)) (cod : Term) (tm : Term) (rec : Bool)
+  | assert (tm : Term)
+  | checkSat
+  | getModel
+  | exit
 
 namespace Command
 
@@ -31,52 +38,42 @@ def defNatSub : Command :=
     (`"ite" • (`"<" • `"x" • `"y") • ``"0" • (`"-" • `"x" • `"y"))
     false
 
-def sortEndsWithNat : Term → Bool
-  | arrowT _ t    => sortEndsWithNat t
-  | symbolT "Nat" => true
-  | _             => false
+open ToSexp in
+protected def toSexp : Command → Sexp
+  | .setLogic l                   => sexp!{(set-logic {l})}
+  | .setOption k v                => sexp!{(set-option {s!":{k}"} {v})}
+  | .assert val                   => sexp!{(assert {toSexp val})}
+  | .declare nm st@(arrowT ..)    =>
+    let sts := arrowToList st
+    sexp!{(declare-fun {quoteSymbol nm} (...{sts.init.map toSexp}) {toSexp sts.getLast!})}
+  | .declare nm st                => sexp!{(declare-const {quoteSymbol nm} {toSexp st})}
+  | .declareSort nm arity         =>
+    sexp!{(declare-sort {quoteSymbol nm} {String.mk (Nat.toDigits 10 arity)})}
+  | .defineSort nm ps tm          =>
+    sexp!{(define-sort {quoteSymbol nm} (...{ps.map toSexp}) {toSexp tm})}
+  | .defineFun nm [] cod tm _     =>
+    sexp!{(define-const {quoteSymbol nm} {toSexp cod} {toSexp tm})}
+  | .defineFun nm ps cod tm false =>
+    sexp!{(define-fun {quoteSymbol nm} {paramsToSexp ps} {toSexp cod} {toSexp tm})}
+  | .defineFun nm ps cod tm true  =>
+    sexp!{(define-fun-rec {quoteSymbol nm} {paramsToSexp ps} {toSexp cod} {toSexp tm})}
+  | .checkSat                     => sexp!{(check-sat)}
+  | .getModel                     => sexp!{(get-model)}
+  | .exit                         => sexp!{(exit)}
+where
+  arrowToList : Term → List Term
+    | arrowT d c => d :: arrowToList c
+    | s          => [s]
+  paramToSexp (p : String × Term) : Sexp := sexp!{({quoteSymbol p.fst} {toSexp p.snd})}
+  paramsToSexp (ps : List (String × Term)) : Sexp := sexp!{(...{ps.map paramToSexp})}
 
-def natAssertBody (t : Term) : Term :=
-  mkApp2 (symbolT ">=") t (literalT "0")
+instance : ToSexp Command := ⟨Command.toSexp⟩
 
-variable [Monad m] [MonadNameGenerator m]
+instance : ToString Command := ⟨toString ∘ ToSexp.toSexp⟩
 
-/-- TODO: refactor to support functions as input (e.g., (Nat → Nat) → Nat). -/
-def natConstAssert (n : String) (args : List Name) : Term → m Term
-  | arrowT i@(symbolT "Nat") t => do
-    let id ← Lean.mkFreshId
-    return (forallT id.toString i
-                   (imp id.toString (← natConstAssert n (id::args) t)))
-  | arrowT a t => do
-    let id ← Lean.mkFreshId
-    return (forallT id.toString a (← natConstAssert n (id::args) t))
-  | _ => pure $ natAssertBody (applyList n args)
-  where
-    imp n t := appT (appT (symbolT "=>") (natAssertBody (symbolT n))) t
-    applyList n : List Name → Term
-      | [] => symbolT n
-      | t :: ts => appT (applyList n ts) (symbolT t.toString)
+instance : ToString (List Command) := ⟨.intercalate "\n" ∘ (.map toString) ∘ .reverse⟩
 
-def emitCommand (s : Solver) (cmd : Command) : m Solver := do
-  let mut s := s
-  match cmd with
-  | .assert val                   => s := s.assert val
-  | .declare nm st@(arrowT ..)    => s := s.declareFun nm st
-  | .declare nm st                => s := s.declareConst nm st
-  | .declareSort nm arity         => s := s.declareSort nm arity
-  | .defineSort nm ps tm          => s := s.defineSort nm ps tm
-  | .defineFun nm ps cod tm true  => s := s.defineFunRec nm ps cod tm
-  | .defineFun nm ps cod tm false => s := s.defineFun nm ps cod tm
-  match cmd with
-  | .declare nm st =>
-    if sortEndsWithNat st then
-      s := s.assert (← natConstAssert nm [] st)
-  | .defineFun nm ps cod _ _ =>
-    if sortEndsWithNat cod then
-      let tmArrow := ps.foldr (init := cod) fun (_, tp) acc => arrowT tp acc
-      s := s.assert (← natConstAssert nm [] tmArrow)
-  | _ => pure ()
-  return s
+instance : ToMessageData (List Command) := ⟨toMessageData ∘ toString⟩
 
 end Command
 end Smt

--- a/Smt/Data/Sexp.lean
+++ b/Smt/Data/Sexp.lean
@@ -74,8 +74,8 @@ partial def parseOneAux : List Substring → Except ParseError (Sexp × List Sub
     if tk.front == ')' then
       throw <| .malformed "unexpected ')'"
     if tk.front == '(' then
-      if let (ss, tk :: tks) ← parseManyAux tks then
-        -- assertion: tk == ')' since parseManyAux only stops on ')'
+      if let (ss, _tk :: tks) ← parseManyAux tks then
+        -- assertion: _tk == ')' since parseManyAux only stops on ')'
         return (expr ss.toList, tks)
       else
         throw <| .incomplete "expected ')'"

--- a/Smt/Data/Sexp.lean
+++ b/Smt/Data/Sexp.lean
@@ -48,7 +48,7 @@ where
     let tk := s.takeWhile fun c => !c.isWhitespace && c != '(' && c != ')'
     if tk.bsize > 0 then
       return (← tokenize (stk.push tk) (s.extract ⟨tk.bsize⟩ ⟨s.bsize⟩))
-    unreachable!
+    else unreachable!
 
   parseOne : List Substring → Except String (Sexp × List Substring)
     | tk :: tks => do

--- a/Smt/Data/Sexp.lean
+++ b/Smt/Data/Sexp.lean
@@ -37,56 +37,76 @@ instance : ToString ParseError where
     | .incomplete msg => s!"incomplete input: {msg}"
     | .malformed msg  => s!"malformed input: {msg}"
 
-partial def parse (s : String) : Except ParseError (List Sexp) := do
-  let tks ← tokenize #[] s.toSubstring
-  parseMany #[] tks.toList |>.map Prod.fst |>.map Array.toList
-where
-  /-- Push tokens found in `s` onto the `stk`. Supported token kinds are more or less as in
-  https://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2021-05-12.pdf:
-  - parentheses `(`/`)`
-  - symbols `abc`
-  - quoted symbols `|abc|`
-  - string literals `"abc"` -/
-  tokenize (stk : Array Substring) (s : Substring) : Except ParseError (Array Substring) :=
-    -- Note: not written using `do` notation to ensure tail-call recursion
-    if s.isEmpty then .ok stk
-    else
-      let c := s.front
-      if c == '"' || c == '|' then
-        let s1 := s.drop 1 |>.takeWhile (· ≠ c)
-        if s1.stopPos = s.stopPos then
-          throw <| .incomplete s!"ending {c} missing after {s1}"
-        else
-          let s1 := ⟨s.str, s.startPos, s.next s1.stopPos⟩
-          let s2 := ⟨s.str, s1.stopPos, s.stopPos⟩
-          tokenize (stk.push s1) s2
-      else if c == ')' || c == '(' then
-        tokenize (stk.push <| s.take 1) (s.drop 1)
-      else if c.isWhitespace then
-        tokenize stk (s.drop 1)
+/-- Tokenize `s` with the s-expression grammar. Supported token kinds are more or less as in
+https://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2021-05-12.pdf:
+- parentheses `(`/`)`
+- symbols `abc`
+- quoted symbols `|abc|`
+- string literals `"abc"` -/
+partial def tokenize (s : Substring) : Except ParseError (Array Substring) :=
+  go #[] s
+where go (stk : Array Substring) (s : Substring) :=
+  -- Note: not written using `do` notation to ensure tail-call recursion
+  if s.isEmpty then .ok stk
+  else
+    let c := s.front
+    if c == '"' || c == '|' then
+      let s1 := s.drop 1 |>.takeWhile (· ≠ c)
+      if s1.stopPos = s.stopPos then
+        throw <| .incomplete s!"ending {c} missing after {s1}"
       else
-        let tk := s.takeWhile fun c =>
-          !c.isWhitespace && c != '(' && c != ')' && c != '|' && c != '"'
-        -- assertion: tk.bsize > 0 as otherwise we would have gone into one of the branches above
-        tokenize (stk.push tk) (s.extract ⟨tk.bsize⟩ ⟨s.bsize⟩)
+        let s1 := ⟨s.str, s.startPos, s.next s1.stopPos⟩
+        let s2 := ⟨s.str, s1.stopPos, s.stopPos⟩
+        go (stk.push s1) s2
+    else if c == ')' || c == '(' then
+      go (stk.push <| s.take 1) (s.drop 1)
+    else if c.isWhitespace then
+      go stk (s.drop 1)
+    else
+      let tk := s.takeWhile fun c =>
+        !c.isWhitespace && c != '(' && c != ')' && c != '|' && c != '"'
+      -- assertion: tk.bsize > 0 as otherwise we would have gone into one of the branches above
+      go (stk.push tk) (s.extract ⟨tk.bsize⟩ ⟨s.bsize⟩)
 
-  parseOne : List Substring → Except ParseError (Sexp × List Substring)
-    | tk :: tks => do
-      if tk.front == ')' then
-        throw <| .malformed "mismatched parentheses"
-      if tk.front == '(' then
-        let (ss, tks) ← parseMany #[] tks
+mutual
+partial def parseOneAux : List Substring → Except ParseError (Sexp × List Substring)
+  | tk :: tks => do
+    if tk.front == ')' then
+      throw <| .malformed "unexpected ')'"
+    if tk.front == '(' then
+      if let (ss, tk :: tks) ← parseManyAux tks then
+        -- assertion: tk == ')' since parseManyAux only stops on ')'
         return (expr ss.toList, tks)
       else
-        return  (atom tk.toString, tks)
-    | [] => throw <| .incomplete "expected input, got none"
+        throw <| .incomplete "expected ')'"
+    else
+      return (atom tk.toString, tks)
+  | [] => throw <| .incomplete "expected a token, got none"
 
-  parseMany (stk : Array Sexp) : List Substring → Except ParseError (Array Sexp × List Substring)
-    | tk :: tks => do
-      if tk.front == ')' then .ok (stk, tks)
-      else
-        let (e, tks) ← parseOne (tk :: tks)
-        parseMany (stk.push e) tks
-    | [] => .ok (stk, [])
+partial def parseManyAux :=
+  go #[]
+where go (stk : Array Sexp) : List Substring → Except ParseError (Array Sexp × List Substring)
+  | tk :: tks => do
+    if tk.front == ')' then .ok (stk, tk :: tks)
+    else
+      let (e, tks) ← parseOneAux (tk :: tks)
+      go (stk.push e) tks
+  | [] => .ok (stk, [])
+end
+
+/-- Parse all the s-expressions in the given string. For example, `"(abc) (def)"` contains two. -/
+def parseMany (s : String) : Except ParseError (List Sexp) := do
+  let tks ← tokenize s.toSubstring
+  let (sexps, tks) ← parseManyAux tks.toList
+  if !tks.isEmpty then
+    throw <| .malformed s!"unexpected '{tks.get! 0}'"
+  return sexps.toList
+
+/-- Parse a single s-expression. Note that the string may contain extra data, but parsing will
+succeed as soon as the single s-exp is complete. -/
+def parseOne (s : String) : Except ParseError Sexp := do
+  let tks ← tokenize s.toSubstring
+  let (sexp, _) ← parseOneAux tks.toList
+  return sexp
 
 end Sexp

--- a/Smt/Data/Sexp.lean
+++ b/Smt/Data/Sexp.lean
@@ -26,42 +26,62 @@ def serializeMany (ss : List Sexp) : String :=
 instance : ToString Sexp :=
   ⟨serialize⟩
 
-partial def parse (s : String) : Except String (List Sexp) := do
+inductive ParseError where
+  | /-- Incomplete input, for example missing a closing parenthesis. -/
+    incomplete (msg : String)
+  | /-- Malformed input, for example having too many closing parentheses. -/
+    malformed (msg : String)
+
+instance : ToString ParseError where
+  toString
+    | .incomplete msg => s!"incomplete input: {msg}"
+    | .malformed msg  => s!"malformed input: {msg}"
+
+partial def parse (s : String) : Except ParseError (List Sexp) := do
   let tks ← tokenize #[] s.toSubstring
   parseMany #[] tks.toList |>.map Prod.fst |>.map Array.toList
 where
-  tokenize (stk : Array Substring) (s : Substring) : Except String (Array Substring) := do
-    if s.isEmpty then
-      return stk
-    let c := s.front
-    if c == '"' then
-      let s1 := s.drop 1 |>.takeWhile (· ≠ '"')
-      if s1.stopPos = s.stopPos then
-        throw "ending \" missing"
-      let s1 := ⟨s.str, s.startPos, s.next s1.stopPos⟩
-      let s2 := ⟨s.str, s1.stopPos, s.stopPos⟩
-      return (← tokenize (stk.push s1) s2)
-    if c == ')' || c == '(' then
-      return (← tokenize (stk.push <| s.take 1) (s.drop 1))
-    if c.isWhitespace then
-      return (← tokenize stk (s.drop 1))
-    let tk := s.takeWhile fun c => !c.isWhitespace && c != '(' && c != ')'
-    if tk.bsize > 0 then
-      return (← tokenize (stk.push tk) (s.extract ⟨tk.bsize⟩ ⟨s.bsize⟩))
-    else unreachable!
+  /-- Push tokens found in `s` onto the `stk`. Supported token kinds are more or less as in
+  https://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2021-05-12.pdf:
+  - parentheses `(`/`)`
+  - symbols `abc`
+  - quoted symbols `|abc|`
+  - string literals `"abc"` -/
+  tokenize (stk : Array Substring) (s : Substring) : Except ParseError (Array Substring) :=
+    -- Note: not written using `do` notation to ensure tail-call recursion
+    if s.isEmpty then .ok stk
+    else
+      let c := s.front
+      if c == '"' || c == '|' then
+        let s1 := s.drop 1 |>.takeWhile (· ≠ c)
+        if s1.stopPos = s.stopPos then
+          throw <| .incomplete s!"ending {c} missing after {s1}"
+        else
+          let s1 := ⟨s.str, s.startPos, s.next s1.stopPos⟩
+          let s2 := ⟨s.str, s1.stopPos, s.stopPos⟩
+          tokenize (stk.push s1) s2
+      else if c == ')' || c == '(' then
+        tokenize (stk.push <| s.take 1) (s.drop 1)
+      else if c.isWhitespace then
+        tokenize stk (s.drop 1)
+      else
+        let tk := s.takeWhile fun c =>
+          !c.isWhitespace && c != '(' && c != ')' && c != '|' && c != '"'
+        -- assertion: tk.bsize > 0 as otherwise we would have gone into one of the branches above
+        tokenize (stk.push tk) (s.extract ⟨tk.bsize⟩ ⟨s.bsize⟩)
 
-  parseOne : List Substring → Except String (Sexp × List Substring)
+  parseOne : List Substring → Except ParseError (Sexp × List Substring)
     | tk :: tks => do
       if tk.front == ')' then
-        throw "mismatched parentheses"
+        throw <| .malformed "mismatched parentheses"
       if tk.front == '(' then
         let (ss, tks) ← parseMany #[] tks
         return (expr ss.toList, tks)
       else
         return  (atom tk.toString, tks)
-    | [] => throw "expected input, got none"
+    | [] => throw <| .incomplete "expected input, got none"
 
-  parseMany (stk : Array Sexp) : List Substring → Except String (Array Sexp × List Substring)
+  parseMany (stk : Array Sexp) : List Substring → Except ParseError (Array Sexp × List Substring)
     | tk :: tks => do
       if tk.front == ')' then .ok (stk, tks)
       else

--- a/Smt/Dsl/Sexp.lean
+++ b/Smt/Dsl/Sexp.lean
@@ -32,7 +32,7 @@ end
 
 instance : ToSexp String := ⟨Sexp.atom⟩
 
-instance [ToSexp α]: Coe α Sexp := ⟨ToSexp.toSexp⟩
+instance [ToSexp α] : Coe α Sexp := ⟨ToSexp.toSexp⟩
 
 declare_syntax_cat sexp
 

--- a/Smt/Dsl/Sexp.lean
+++ b/Smt/Dsl/Sexp.lean
@@ -30,8 +30,9 @@ def Lean.TSyntax.getGeneralId : TSyntax `generalIdent → String
 @[combinatorParenthesizer generalIdent] def generalIdent.parenthesizer : Parenthesizer := pure ()
 end
 
-instance : Coe String Sexp :=
-  ⟨Sexp.atom⟩
+instance : ToSexp String := ⟨Sexp.atom⟩
+
+instance [ToSexp α]: Coe α Sexp := ⟨ToSexp.toSexp⟩
 
 declare_syntax_cat sexp
 

--- a/Smt/Solver.lean
+++ b/Smt/Solver.lean
@@ -91,13 +91,13 @@ private def addCommand (c : Command) : SolverT m Unit := do
 private def getSexp : SolverT m Sexp := do
   let state ← get
   let mut out ← state.proc.stdout.getLine
-  let mut sexpRes := Sexp.parse out
+  let mut sexpRes := Sexp.parseOne out
   while sexpRes matches .error (.incomplete _) do
     out := out ++ (← state.proc.stdout.getLine)
-    sexpRes := Sexp.parse out
-  if let .ok [sexp!{(error {.atom e})}] := sexpRes then
+    sexpRes := Sexp.parseOne out
+  if let .ok sexp!{(error {.atom e})} := sexpRes then
     (throw (IO.userError (unquote e)) : IO Unit)
-  if let .ok [res] := sexpRes then
+  if let .ok res := sexpRes then
     return res
   let err ← state.proc.stderr.readToEnd
   (throw (IO.userError s!"something went wrong.\nstdout:\n{out}\nstderr:\n{err}") : IO Unit)

--- a/Smt/Solver.lean
+++ b/Smt/Solver.lean
@@ -91,13 +91,13 @@ private def addCommand (c : Command) : SolverT m Unit := do
 private def getSexp : SolverT m Sexp := do
   let state ← get
   let mut out ← state.proc.stdout.getLine
-  let mut sexp := Sexp.parse out
-  while ¬sexp.toBool do
+  let mut sexpRes := Sexp.parse out
+  while sexpRes matches .error (.incomplete _) do
     out := out ++ (← state.proc.stdout.getLine)
-    sexp := Sexp.parse out
-  if let .ok [sexp!{(error {.atom e})}] := sexp then
+    sexpRes := Sexp.parse out
+  if let .ok [sexp!{(error {.atom e})}] := sexpRes then
     (throw (IO.userError (unquote e)) : IO Unit)
-  if let .ok [res] := sexp then
+  if let .ok [res] := sexpRes then
     return res
   let err ← state.proc.stderr.readToEnd
   (throw (IO.userError s!"something went wrong.\nstdout:\n{out}\nstderr:\n{err}") : IO Unit)

--- a/Smt/Solver.lean
+++ b/Smt/Solver.lean
@@ -82,28 +82,31 @@ abbrev SolverM := SolverT IO
 
 namespace Solver
 
-private def addCommand (c : Command) : SolverT m Unit := do
+def emitCommand (c : Command) : SolverT m Unit := do
   let state ← get
   set { state with commands := c :: state.commands }
   state.proc.stdin.putStr s!"{c}\n"
   state.proc.stdin.flush
 
+def emitCommands : List Command → SolverT m Unit := (List.forM · emitCommand)
+
 private def getSexp : SolverT m Sexp := do
   let state ← get
   let mut out ← state.proc.stdout.getLine
-  let mut sexpRes := Sexp.parseOne out
-  while sexpRes matches .error (.incomplete _) do
+  let mut parseRes := Sexp.parseOne out
+  while !(← (state.proc.stdout.isEof : IO _)) && parseRes matches .error (.incomplete _) do
     out := out ++ (← state.proc.stdout.getLine)
-    sexpRes := Sexp.parseOne out
-  if let .ok sexp!{(error {.atom e})} := sexpRes then
-    (throw (IO.userError (unquote e)) : IO Unit)
-  if let .ok res := sexpRes then
-    return res
-  let err ← state.proc.stderr.readToEnd
-  (throw (IO.userError s!"something went wrong.\nstdout:\n{out}\nstderr:\n{err}") : IO Unit)
-  return default
+    parseRes := Sexp.parseOne out
+  match parseRes with
+  | .ok sexp!{(error {.atom e})} => (throw (IO.userError (unquote e)) : IO _)
+  | .ok sexp => return sexp
+  | .error e =>
+    let err ← state.proc.stderr.readToEnd
+    (throw (IO.userError (parseErrMsg e out err)) : IO _)
 where
-  unquote (s : String) := s.extract ⟨1⟩ ⟨s.length - 1⟩
+  unquote s := s.extract ⟨1⟩ ⟨s.length - 1⟩
+  parseErrMsg (e : Sexp.ParseError) (out err : String) :=
+    s!"could not parse solver output: {e}\nsolver stdout:\n{out}\nsolver stderr:\n{err}"
 
 /-- Create an instance of a generic SMT solver.
     Note: `args` is only for enabling interactive SMT-LIB interface for solvers. To set other
@@ -119,10 +122,10 @@ def create (path : String) (args : Array String) : IO SolverState := do
   return ⟨[], proc⟩
 
 /-- Create an instance of a pre-configured SMT solver. -/
-def createFromKind (kind : Kind) (path : Option String) (timeoutSecs? : Option Nat := some 5) :
+def createFromKind (kind : Kind) (path : Option String) (timeoutSecs : Option Nat) :
   IO SolverState := do
   let mut args := kindToArgs kind
-  if let some secs := timeoutSecs? then
+  if let some secs := timeoutSecs then
     args := args ++ timeoutArgs secs kind
   create (path.getD (toString kind)) args
 where
@@ -142,46 +145,46 @@ where
     | .z3        => #[s!"-T:{secs}"]
 
 /-- Set the SMT query logic to `l`. -/
-def setLogic (l : String) : SolverT m Unit := addCommand (.setLogic l)
+def setLogic (l : String) : SolverT m Unit := emitCommand (.setLogic l)
 
 /-- Set option `k` to value `v`. -/
-def setOption (k : String) (v : String) : SolverT m Unit := addCommand (.setOption k v)
+def setOption (k : String) (v : String) : SolverT m Unit := emitCommand (.setOption k v)
 
 /-- Define a sort with name `id` and arity `n`. -/
-def declareSort (id : String) (n : Nat) : SolverT m Unit := addCommand (.declareSort id n)
+def declareSort (id : String) (n : Nat) : SolverT m Unit := emitCommand (.declareSort id n)
 
 /-- Define a sort with name `id`. -/
 def defineSort (id : String) (ss : List Term) (s : Term) : SolverT m Unit :=
-  addCommand (.defineSort id ss s)
+  emitCommand (.defineSort id ss s)
 
 /-- Declare a symbolic constant with name `id` and sort `s`. -/
-def declareConst (id : String) (s : Term) : SolverT m Unit := addCommand (.declare id s)
+def declareConst (id : String) (s : Term) : SolverT m Unit := emitCommand (.declare id s)
 
 /-- Declare an uninterpreted function with name `id` and sort `s`. -/
-def declareFun (id : String) (s : Term) : SolverT m Unit := addCommand (.declare id s)
+def declareFun (id : String) (s : Term) : SolverT m Unit := emitCommand (.declare id s)
 
 /-- Define a function with name `id`, parameters `ps`, co-domain `s`,
     and body `t`. -/
 def defineFun (id : String) (ps : List (String × Term)) (s : Term) (t : Term) :
-  SolverT m Unit := addCommand (.defineFun id ps s t false)
+  SolverT m Unit := emitCommand (.defineFun id ps s t false)
 
 /-- Define a recursive function with name `id`, parameters `ps`, co-domain `s`,
     and body `t`. -/
 def defineFunRec (id : String) (ps : List (String × Term)) (s : Term) (t : Term) :
-  SolverT m Unit := addCommand (.defineFun id ps s t true)
+  SolverT m Unit := emitCommand (.defineFun id ps s t true)
 
 /-- Assert that proposition `t` is true. -/
-def assert (t : Term) : SolverT m Unit := addCommand (.assert t)
+def assert (t : Term) : SolverT m Unit := emitCommand (.assert t)
 
 /-- Check if the query given so far is satisfiable and return the result. -/
 def checkSat : SolverT m Result := do
-  addCommand .checkSat
+  emitCommand .checkSat
   let out ← getSexp
   let res ← match out with
     | "sat"     => return .sat
     | "unsat"   => return .unsat
     | "unknown" => return .unknown
-    | _ => (throw (IO.userError s!"unexpected solver output: {repr out}") : IO Result)
+    | _ => (throw (IO.userError s!"unexpected solver output: {repr out}") : IO _)
   return res
 
 /- TODO: We should probably parse the returned string into `Command`s or `String × Term`s. This is
@@ -189,61 +192,21 @@ def checkSat : SolverT m Result := do
    should be possible, however, because we store a list of all executed commands. -/
 /-- Return the model for a `sat` result. -/
 def getModel : SolverT m String := do
-  addCommand .getModel
-  toString <$> getSexp
+  emitCommand .getModel
+  prettyPrint <$> getSexp
+where
+  prettyPrint : Sexp → String
+    | .atom _  => unreachable!
+    | .expr es => match es with
+      | [] => "()"
+      | es => "(\n" ++ String.intercalate "\n" (es.map toString) ++ "\n)"
 
 /-- Check if the query given so far is satisfiable and return the result. -/
 def exit : SolverT m UInt32 := do
-  addCommand .exit
+  emitCommand .exit
   let state ← get
   -- Close stdin to signal EOF to the solver.
   let (_, proc) ← state.proc.takeStdin
   proc.wait
 
-end Solver
-
-def sortEndsWithNat : Term → Bool
-  | .arrowT _ t    => sortEndsWithNat t
-  | .symbolT "Nat" => true
-  | _              => false
-
-def natAssertBody (t : Term) : Term :=
-  .mkApp2 (.symbolT ">=") t (.literalT "0")
-
-open Lean Term in
-/-- TODO: remove this hack once we have a tactic that replaces Nat goals with Int goals. -/
-def natConstAssert (n : String) (args : List Name) : Term → MetaM Term
-  | arrowT i@(symbolT "Nat") t => do
-    let id ← mkFreshId
-    return (forallT id.toString i
-                   (imp id.toString (← natConstAssert n (id::args) t)))
-  | arrowT a t => do
-    let id ← mkFreshId
-    return (forallT id.toString a (← natConstAssert n (id::args) t))
-  | _ => pure $ natAssertBody (applyList n args)
-  where
-    imp n t := appT (appT (symbolT "=>") (natAssertBody (symbolT n))) t
-    applyList n : List Name → Term
-      | [] => symbolT n
-      | t :: ts => appT (applyList n ts) (symbolT t.toString)
-
-open Solver Lean Term in
-/-- TODO: This function is the same as `addCommand` but with `Nat` hacks.
-    Remove those hacks.  -/
-def emitCommand (cmd : Command) : SolverT MetaM (Unit) := do
-  addCommand cmd
-  match cmd with
-  | .declare nm st =>
-    if sortEndsWithNat st then
-      let x ← natConstAssert nm [] st
-      assert x
-  | .defineFun nm ps cod _ _ =>
-    if sortEndsWithNat cod then
-      let tmArrow := ps.foldr (init := cod) fun (_, tp) acc => arrowT tp acc
-      assert (← natConstAssert nm [] tmArrow)
-  | _ => pure ()
-  pure ()
-
-def emitCommands := (List.forM · emitCommand)
-
-end Smt
+end Smt.Solver

--- a/Smt/Solver.lean
+++ b/Smt/Solver.lean
@@ -128,8 +128,8 @@ def createFromKind (kind : Kind) (path : Option String) (timeoutSecs? : Option N
 where
   kindToArgs : Kind → Array String
     | .boolector => #["--smt2"]
-    | .cvc4      => #["--quiet", "--lang", "smt"]
-    | .cvc5      => #["--quiet", "--lang", "smt"]
+    | .cvc4      => #["--quiet", "--incremental", "--lang", "smt"]
+    | .cvc5      => #["--quiet", "--incremental", "--lang", "smt"]
     | .vampire   => #["--input_syntax", "smtlib2", "--output_mode", "smtcomp"]
     | .yices     => #[]
     | .z3        => #["-in", "-smt2"]

--- a/Smt/Solver.lean
+++ b/Smt/Solver.lean
@@ -190,18 +190,7 @@ def checkSat : SolverT m Result := do
 /-- Return the model for a `sat` result. -/
 def getModel : SolverT m String := do
   addCommand .getModel
-  -- TODO: Replace the lines below with `getSexp` once `Sexp.parse` becomes strict.
-  let state ← get
-  let mut (ops, cps) := (0, 0)
-  let mut res := ""
-  while ops = 0 ∨ ops ≠ cps do
-    let ln ← state.proc.stdout.getLine
-    ops := ops + count '(' ln
-    cps := cps + count ')' ln
-    res := res ++ ln
-  return res
-where
-  count (c : Char) (s : String) : Nat := s.data |>.filter (· = c) |>.length
+  toString <$> getSexp
 
 /-- Check if the query given so far is satisfiable and return the result. -/
 def exit : SolverT m UInt32 := do

--- a/Smt/Solver.lean
+++ b/Smt/Solver.lean
@@ -95,7 +95,7 @@ private def getSexp : SolverT m Sexp := do
   while ¬sexp.toBool do
     out := out ++ (← state.proc.stdout.getLine)
     sexp := Sexp.parse out
-  if let .ok [.expr [.atom "error", .atom e]] := sexp then
+  if let .ok [sexp!{(error {.atom e})}] := sexp then
     (throw (IO.userError (unquote e)) : IO Unit)
   return sexp.toOption.get!.head!
 where
@@ -152,10 +152,6 @@ def defineSort (id : String) (ss : List Term) (s : Term) : SolverT m Unit :=
 
 /-- Declare a symbolic constant with name `id` and sort `s`. -/
 def declareConst (id : String) (s : Term) : SolverT m Unit := addCommand (.declare id s)
-
-/-- Define a constant with name `id` sort `s`, and value `v`. -/
-def defineConst (id : String) (s : Term) (v : Term) : SolverT m Unit :=
-  addCommand (.defineFun id [] s v false)
 
 /-- Declare an uninterpreted function with name `id` and sort `s`. -/
 def declareFun (id : String) (s : Term) : SolverT m Unit := addCommand (.declare id s)

--- a/Smt/Solver.lean
+++ b/Smt/Solver.lean
@@ -74,13 +74,13 @@ structure SolverState where
   commands : List Command
   proc : IO.Process.Child ⟨.piped, .piped, .piped⟩
 
-variable [Monad m] [MonadLiftT IO m]
-
 abbrev SolverT (m) [Monad m] [MonadLiftT IO m] := StateT SolverState m
 
 abbrev SolverM := SolverT IO
 
 namespace Solver
+
+variable [Monad m] [MonadLiftT IO m]
 
 def emitCommand (c : Command) : SolverT m Unit := do
   let state ← get

--- a/Smt/Solver.lean
+++ b/Smt/Solver.lean
@@ -239,21 +239,10 @@ def natConstAssert (n : String) (args : List Name) : Term → MetaM Term
       | t :: ts => appT (applyList n ts) (symbolT t.toString)
 
 open Solver Lean Term in
+/-- TODO: This function is the same as `addCommand` but with `Nat` hacks.
+    Remove those hacks.  -/
 def emitCommand (cmd : Command) : SolverT MetaM (Unit) := do
-  match cmd with
-  | .setLogic l                   => setLogic l
-  | .setOption k v                => setOption k v
-  | .assert val                   => assert val
-  | .declare nm st@(.arrowT ..)   => declareFun nm st
-  | .declare nm st                => declareConst nm st
-  | .declareSort nm arity         => declareSort nm arity
-  | .defineSort nm ps tm          => defineSort nm ps tm
-  | .defineFun nm [] cod tm _     => defineConst nm cod tm
-  | .defineFun nm ps cod tm true  => defineFunRec nm ps cod tm
-  | .defineFun nm ps cod tm false => defineFun nm ps cod tm
-  | .checkSat                     => _ ← checkSat
-  | .getModel                     => _ ← getModel
-  | .exit                         => _ ← exit
+  addCommand cmd
   match cmd with
   | .declare nm st =>
     if sortEndsWithNat st then

--- a/Smt/Tactic/Smt.lean
+++ b/Smt/Tactic/Smt.lean
@@ -86,7 +86,7 @@ def prepareSmtQuery (hints : TSyntax `smtHints) : TacticM (List Command) := do
   let ss ← createFromKind kind path
   let (res, ss) ← (StateT.run query ss : MetaM _)
   -- 5. Print the result.
-  logInfo m!"goal: {goalType}\n\nquery:\n{ss.commands.init}\n\nresult: {res}"
+  logInfo m!"goal: {goalType}\n\nquery:\n{Command.cmdsAsQuery ss.commands.init}\n\nresult: {res}"
   if res = .sat then
     let (model, _) ← StateT.run getModel ss
     logInfo m!"\ncounter-model:\n{model}"

--- a/Smt/Tactic/Smt.lean
+++ b/Smt/Tactic/Smt.lean
@@ -78,7 +78,7 @@ def prepareSmtQuery (hints : TSyntax `smtHints) : TacticM (List Command) := do
 @[tactic smt] def evalSmt : Tactic := fun stx => withMainContext do
   let goalType ← Tactic.getMainTarget
   let query := setOption "produce-models" "true"
-            *> emitCommands (← prepareSmtQuery ⟨stx[1]⟩)
+            *> emitCommands (← prepareSmtQuery ⟨stx[1]⟩).reverse
             *> checkSat
   -- 4. Run the solver.
   let kind := smt.solver.kind.get (← getOptions)

--- a/Smt/Util.lean
+++ b/Smt/Util.lean
@@ -36,7 +36,7 @@ def exprToString : Expr → String
   | proj s i e       => s!"(PROJ {s} {i} {exprToString e})"
   where
     literalToString : Literal → String
-      | Literal.natVal v => ⟨Nat.toDigits 10 v⟩
+      | Literal.natVal v => toString v
       | Literal.strVal v => v
 
 /-- Count the number of occurances of the constant `c` in `e`. -/

--- a/Test/Bool/Assoc.expected
+++ b/Test/Bool/Assoc.expected
@@ -9,4 +9,12 @@ query:
 (check-sat)
 
 result: sat
+
+counter-model:
+(
+(define-fun f ((_arg_1 Bool) (_arg_2 Bool)) Bool (ite _arg_1 (not _arg_2) (and (not _arg_1) (not _arg_2))))
+(define-fun p () Bool true)
+(define-fun q () Bool false)
+(define-fun r () Bool false)
+)
 Test/Bool/Assoc.lean:5:2: error: unable to prove goal, either it is false or you need to define more symbols with `smt [foo, bar]`

--- a/Test/Bool/Comm.expected
+++ b/Test/Bool/Comm.expected
@@ -8,4 +8,11 @@ query:
 (check-sat)
 
 result: sat
+
+counter-model:
+(
+(define-fun f ((_arg_1 Bool) (_arg_2 Bool)) Bool (and _arg_1 (not _arg_2)))
+(define-fun p () Bool false)
+(define-fun q () Bool true)
+)
 Test/Bool/Comm.lean:4:2: error: unable to prove goal, either it is false or you need to define more symbols with `smt [foo, bar]`

--- a/Test/Int/DvdTimeout.expected
+++ b/Test/Int/DvdTimeout.expected
@@ -1,5 +1,19 @@
-Test/Int/DvdTimeout.lean:13:4: error: something went wrong.
-stdout:
+goal: dvd a (b + c + d) = true
 
-stderr:
+query:
+(declare-fun dvd (Int Int) Bool)
+(assert (forall ((x Int)) (forall ((y Int)) (forall ((z Int)) (=> (= (dvd x y) true) (=> (= (dvd x z) true) (= (dvd x (+ y z)) true)))))))
+(declare-const c Int)
+(declare-const a Int)
+(assert (= (dvd a c) true))
+(declare-const d Int)
+(declare-const b Int)
+(assert (not (= (dvd a (+ (+ b c) d)) true)))
+(assert (= (dvd a b) true))
+(assert (= (dvd a d) true))
+(check-sat)
+Test/Int/DvdTimeout.lean:13:4: error: could not parse solver output: incomplete input: expected a token, got none
+solver stdout:
+
+solver stderr:
 cvc5 interrupted by timeout.

--- a/Test/Int/DvdTimeout.expected
+++ b/Test/Int/DvdTimeout.expected
@@ -1,18 +1,5 @@
-goal: dvd a (b + c + d) = true
+Test/Int/DvdTimeout.lean:13:4: error: something went wrong.
+stdout:
 
-query:
-(declare-fun dvd (Int Int) Bool)
-(assert (forall ((x Int)) (forall ((y Int)) (forall ((z Int)) (=> (= (dvd x y) true) (=> (= (dvd x z) true) (= (dvd x (+ y z)) true)))))))
-(declare-const c Int)
-(declare-const a Int)
-(assert (= (dvd a c) true))
-(declare-const d Int)
-(declare-const b Int)
-(assert (not (= (dvd a (+ (+ b c) d)) true)))
-(assert (= (dvd a b) true))
-(assert (= (dvd a d) true))
-(check-sat)
-
-result: 
+stderr:
 cvc5 interrupted by timeout.
-Test/Int/DvdTimeout.lean:13:4: error: unable to prove goal

--- a/Test/Int/Let.expected
+++ b/Test/Int/Let.expected
@@ -21,7 +21,7 @@ goal: f z = z
 
 query:
 (declare-fun f (Int) Int)
-(define-fun z () Int 10)
+(define-const z Int 10)
 (assert (not (= (f z) z)))
 (assert (= (f 10) 10))
 (check-sat)
@@ -31,8 +31,8 @@ goal: f y = y
 
 query:
 (declare-fun f (Int) Int)
-(define-fun z () Int 10)
-(define-fun y () Int z)
+(define-const z Int 10)
+(define-const y Int z)
 (assert (not (= (f y) y)))
 (assert (= (f 10) 10))
 (check-sat)

--- a/Test/Int/Let.expected
+++ b/Test/Int/Let.expected
@@ -21,7 +21,7 @@ goal: f z = z
 
 query:
 (declare-fun f (Int) Int)
-(define-const z Int 10)
+(define-fun z () Int 10)
 (assert (not (= (f z) z)))
 (assert (= (f 10) 10))
 (check-sat)
@@ -31,8 +31,8 @@ goal: f y = y
 
 query:
 (declare-fun f (Int) Int)
-(define-const z Int 10)
-(define-const y Int z)
+(define-fun z () Int 10)
+(define-fun y () Int z)
 (assert (not (= (f y) y)))
 (assert (= (f 10) 10))
 (check-sat)

--- a/Test/Nat/NeqZero.expected
+++ b/Test/Nat/NeqZero.expected
@@ -7,8 +7,7 @@ query:
 result: sat
 
 counter-model:
-(
-)
+()
 Test/Nat/NeqZero.lean:4:2: error: unable to prove goal, either it is false or you need to define more symbols with `smt [foo, bar]`
 goal: ∀ (x : Nat), x + 1 ≠ 0
 

--- a/Test/Nat/NeqZero.expected
+++ b/Test/Nat/NeqZero.expected
@@ -5,6 +5,10 @@ query:
 (check-sat)
 
 result: sat
+
+counter-model:
+(
+)
 Test/Nat/NeqZero.lean:4:2: error: unable to prove goal, either it is false or you need to define more symbols with `smt [foo, bar]`
 goal: ∀ (x : Nat), x + 1 ≠ 0
 

--- a/Test/Prop/Assoc.expected
+++ b/Test/Prop/Assoc.expected
@@ -9,4 +9,12 @@ query:
 (check-sat)
 
 result: sat
+
+counter-model:
+(
+(define-fun f ((_arg_1 Bool) (_arg_2 Bool)) Bool (ite _arg_1 (not _arg_2) (and (not _arg_1) (not _arg_2))))
+(define-fun p () Bool true)
+(define-fun q () Bool false)
+(define-fun r () Bool false)
+)
 Test/Prop/Assoc.lean:5:2: error: unable to prove goal, either it is false or you need to define more symbols with `smt [foo, bar]`

--- a/Test/Prop/Comm.expected
+++ b/Test/Prop/Comm.expected
@@ -8,4 +8,11 @@ query:
 (check-sat)
 
 result: sat
+
+counter-model:
+(
+(define-fun f ((_arg_1 Bool) (_arg_2 Bool)) Bool (and _arg_1 (not _arg_2)))
+(define-fun p () Bool false)
+(define-fun q () Bool true)
+)
 Test/Prop/Comm.lean:4:2: error: unable to prove goal, either it is false or you need to define more symbols with `smt [foo, bar]`

--- a/Test/Solver/Error.expected
+++ b/Test/Solver/Error.expected
@@ -1,0 +1,5 @@
+
+Test/Solver/Error.lean:17:0: error: Parse Error: <stdin>:2.20: Cannot bind x to symbol of type Int, maybe the symbol has already been defined?
+
+  (declare-const x Int)
+                   ^

--- a/Test/Solver/Error.expected
+++ b/Test/Solver/Error.expected
@@ -1,5 +1,5 @@
 
-Test/Solver/Error.lean:17:0: error: Parse Error: <stdin>:2.20: Cannot bind x to symbol of type Int, maybe the symbol has already been defined?
+Test/Solver/Error.lean:15:0: error: Parse Error: <stdin>:2.20: Cannot bind x to symbol of type Int, maybe the symbol has already been defined?
 
   (declare-const x Int)
                    ^

--- a/Test/Solver/Error.lean
+++ b/Test/Solver/Error.lean
@@ -9,7 +9,7 @@ def query : SolverM Result := do
   checkSat
 
 def main : IO Unit := do
-  let ss ← createFromKind .cvc5 "cvc5"
+  let ss ← createFromKind .cvc5 "cvc5" none
   _ ← StateT.run query ss
 
 #eval main

--- a/Test/Solver/Error.lean
+++ b/Test/Solver/Error.lean
@@ -10,8 +10,6 @@ def query : SolverM Result := do
 
 def main : IO Unit := do
   let ss ← createFromKind .cvc5 "cvc5"
-  let (res, ss) ← StateT.run query ss
-  _ ← StateT.run exit ss
-  println! "query:\n{ss.commands}\n\nres: {res}"
+  _ ← StateT.run query ss
 
 #eval main

--- a/Test/Solver/Error.lean
+++ b/Test/Solver/Error.lean
@@ -1,0 +1,17 @@
+import Smt.Solver
+
+open Smt Solver
+
+def query : SolverM Result := do
+  setLogic "LIA"
+  declareConst "x" (.symbolT "Int")
+  declareConst "x" (.symbolT "Int")
+  checkSat
+
+def main : IO Unit := do
+  let ss ← createFromKind .cvc5 "cvc5"
+  let (res, ss) ← StateT.run query ss
+  _ ← StateT.run exit ss
+  println! "query:\n{ss.commands}\n\nres: {res}"
+
+#eval main

--- a/Test/Solver/Interactive.expected
+++ b/Test/Solver/Interactive.expected
@@ -1,0 +1,10 @@
+query:
+(set-logic LIA)
+(declare-const x Int)
+(declare-const y Int)
+(assert (< x y))
+(check-sat)
+(assert (> (+ x 1) y))
+(check-sat)
+
+res: unsat

--- a/Test/Solver/Interactive.lean
+++ b/Test/Solver/Interactive.lean
@@ -20,6 +20,6 @@ def main : IO Unit := do
   let ss ← createFromKind .cvc5 "cvc5"
   let (res, ss) ← StateT.run query ss
   _ ← StateT.run exit ss
-  println! "query:\n{ss.commands}\n\nres: {res}"
+  println! "query:\n{Command.cmdsAsQuery ss.commands}\n\nres: {res}"
 
 #eval main

--- a/Test/Solver/Interactive.lean
+++ b/Test/Solver/Interactive.lean
@@ -1,0 +1,25 @@
+import Smt.Solver
+
+open Smt Solver
+
+open Term in
+def query : SolverM Result := do
+  setLogic "LIA"
+  declareConst "x" (symbolT "Int")
+  declareConst "y" (symbolT "Int")
+  assert (mkApp2 (symbolT "<") (symbolT "x") (symbolT "y"))
+  let mut res ← checkSat
+  if res = .sat then
+    assert (mkApp2 (symbolT ">")
+                    ((mkApp2 (symbolT "+") (symbolT "x") (literalT "1")))
+                    (symbolT "y"))
+    res ← checkSat
+  return res
+
+def main : IO Unit := do
+  let ss ← createFromKind .cvc5 "cvc5"
+  let (res, ss) ← StateT.run query ss
+  _ ← StateT.run exit ss
+  println! "query:\n{ss.commands}\n\nres: {res}"
+
+#eval main

--- a/Test/Solver/Interactive.lean
+++ b/Test/Solver/Interactive.lean
@@ -17,7 +17,7 @@ def query : SolverM Result := do
   return res
 
 def main : IO Unit := do
-  let ss ← createFromKind .cvc5 "cvc5"
+  let ss ← createFromKind .cvc5 "cvc5" none
   let (res, ss) ← StateT.run query ss
   _ ← StateT.run exit ss
   println! "query:\n{Command.cmdsAsQuery ss.commands}\n\nres: {res}"

--- a/Test/Solver/Model.expected
+++ b/Test/Solver/Model.expected
@@ -1,0 +1,14 @@
+query:
+(set-logic LIA)
+(set-option :produce-models true)
+(declare-const x Int)
+(check-sat)
+(get-model)
+
+res: sat
+
+model:
+(
+(define-fun x () Int 0)
+)
+

--- a/Test/Solver/Model.expected
+++ b/Test/Solver/Model.expected
@@ -11,4 +11,3 @@ model:
 (
 (define-fun x () Int 0)
 )
-

--- a/Test/Solver/Model.lean
+++ b/Test/Solver/Model.lean
@@ -1,0 +1,17 @@
+import Smt.Solver
+
+open Smt Solver
+
+def query : SolverM (Result × Sexp) := do
+  setLogic "LIA"
+  setOption "produce-models" "true"
+  declareConst "x" (.symbolT "Int")
+  return (← checkSat, ← getModel)
+
+def main : IO Unit := do
+  let ss ← createFromKind .cvc5 "cvc5"
+  let ((res, model), ss) ← StateT.run query ss
+  _ ← StateT.run exit ss
+  println! "query:\n{ss.commands}\n\nres: {res}\n\nmodel:\n{model}"
+
+#eval main

--- a/Test/Solver/Model.lean
+++ b/Test/Solver/Model.lean
@@ -9,7 +9,7 @@ def query : SolverM (Result × Sexp) := do
   return (← checkSat, ← getModel)
 
 def main : IO Unit := do
-  let ss ← createFromKind .cvc5 "cvc5"
+  let ss ← createFromKind .cvc5 "cvc5" none
   let ((res, model), ss) ← StateT.run query ss
   _ ← StateT.run exit ss
   println! "query:\n{Command.cmdsAsQuery ss.commands}\n\nres: {res}\n\nmodel:\n{model}"

--- a/Test/Solver/Model.lean
+++ b/Test/Solver/Model.lean
@@ -12,6 +12,6 @@ def main : IO Unit := do
   let ss ← createFromKind .cvc5 "cvc5"
   let ((res, model), ss) ← StateT.run query ss
   _ ← StateT.run exit ss
-  println! "query:\n{ss.commands}\n\nres: {res}\n\nmodel:\n{model}"
+  println! "query:\n{Command.cmdsAsQuery ss.commands}\n\nres: {res}\n\nmodel:\n{model}"
 
 #eval main

--- a/Test/Solver/Triv.expected
+++ b/Test/Solver/Triv.expected
@@ -1,0 +1,4 @@
+query:
+(check-sat)
+
+res: sat

--- a/Test/Solver/Triv.lean
+++ b/Test/Solver/Triv.lean
@@ -5,7 +5,7 @@ open Smt Solver
 def query : SolverM Result := checkSat
 
 def main : IO Unit := do
-  let ss ← createFromKind .cvc5 "cvc5"
+  let ss ← createFromKind .cvc5 "cvc5" none
   let (res, ss) ← StateT.run query ss
   _ ← StateT.run exit ss
   println! "query:\n{Command.cmdsAsQuery ss.commands}\n\nres: {res}"

--- a/Test/Solver/Triv.lean
+++ b/Test/Solver/Triv.lean
@@ -1,0 +1,13 @@
+import Smt.Solver
+
+open Smt Solver
+
+def query : SolverM Result := checkSat
+
+def main : IO Unit := do
+  let ss ← createFromKind .cvc5 "cvc5"
+  let (res, ss) ← StateT.run query ss
+  _ ← StateT.run exit ss
+  println! "query:\n{ss.commands}\n\nres: {res}"
+
+#eval main

--- a/Test/Solver/Triv.lean
+++ b/Test/Solver/Triv.lean
@@ -8,6 +8,6 @@ def main : IO Unit := do
   let ss ← createFromKind .cvc5 "cvc5"
   let (res, ss) ← StateT.run query ss
   _ ← StateT.run exit ss
-  println! "query:\n{ss.commands}\n\nres: {res}"
+  println! "query:\n{Command.cmdsAsQuery ss.commands}\n\nres: {res}"
 
 #eval main


### PR DESCRIPTION
The refactoring includes initial support for the `get-model` command and propagation of solver errors. The monad utilizes S-exprs (slightly modified) to communicate with the solver.