### PR TITLE
Add more `QF_BV` builtins

### DIFF
--- a/Smt/BitVec.lean
+++ b/Smt/BitVec.lean
@@ -22,6 +22,7 @@ open Translator Term
     return mkApp2 (symbolT "_") (symbolT "BitVec") (literalT (toString n))
   | _ => return none
 
+/-- Make a binary bitvector literal with value `n` and width `w`. -/
 def mkLit (w : Nat) (n : Nat) : Term :=
   let bits := Nat.toDigits 2 n |>.take w
   literalT <| bits.foldl (init := "#b".pushn '0' (w - bits.length)) (·.push ·)
@@ -34,7 +35,23 @@ def mkLit (w : Nat) (n : Nat) : Term :=
   | _ => return none
 
 @[smtTranslator] def replaceFun : Translator
-  | app (app (const ``BitVec.append _) _) _ => return symbolT "concat"
+  | e@(app (const ``BitVec.zero _) w) => do
+    let w ← reduceWidth w e
+    if w == 0 then throwError "cannot emit bitvector literal{indentD e}\nof bitwidth 0"
+    return mkLit w 0
+  | e@(app (app (const ``BitVec.ofNat _) w) n) => do
+    let w ← reduceWidth w e
+    let n ← reduceLit n e
+    if w == 0 then throwError "cannot emit bitvector literal{indentD e}\nof bitwidth 0"
+    return mkLit w n
+  | app (const ``BitVec.add _) _            => return symbolT "bvadd"
+  | app (const ``BitVec.sub _) _            => return symbolT "bvsub"
+  | app (const ``BitVec.mul _) _            => return symbolT "bvmul"
+  | app (const ``BitVec.mod _) _            => return symbolT "bvurem"
+  | app (const ``BitVec.div _) _            => return symbolT "bvudiv"
+  | app (const ``BitVec.lt _) _             => return symbolT "bvult"
+  | app (const ``BitVec.le _) _             => return symbolT "bvule"
+  | app (const ``BitVec.complement _) _     => return symbolT "bvnot"
   | app (const ``BitVec.and _) _            => return symbolT "bvand"
   | app (const ``BitVec.or _) _             => return symbolT "bvor"
   | app (const ``BitVec.xor _) _            => return symbolT "bvxor"
@@ -48,19 +65,30 @@ def mkLit (w : Nat) (n : Nat) : Term :=
     let n ← reduceLit n e
     if w == 0 then throwError "cannot emit bitvector literal{indentD e}\nof bitwidth 0"
     return mkApp2 (symbolT "bvlshr") (← applyTranslators! x) (mkLit w n)
+  | e@(app (app (app (const ``BitVec.rotateLeft _) _) x) n) => do
+    let n ← reduceLit n e
+    return appT
+      (mkApp2 (symbolT "_") (symbolT "rotate_left") (literalT (toString n)))
+      (← applyTranslators! x)
+  | e@(app (app (app (const ``BitVec.rotateRight _) _) x) n) => do
+    let n ← reduceLit n e
+    return appT
+      (mkApp2 (symbolT "_") (symbolT "rotate_right") (literalT (toString n)))
+      (← applyTranslators! x)
+  | app (app (const ``BitVec.append _) _) _ => return symbolT "concat"
   | e@(app (app (app (const ``BitVec.extract _) _) i) j) => do
     let i ← reduceLit i e
     let j ← reduceLit j e
     return mkApp3 (symbolT "_") (symbolT "extract") (literalT (toString i)) (literalT (toString j))
-  | e@(app (const ``BitVec.zero _) w) => do
-    let w ← reduceWidth w e
-    if w == 0 then throwError "cannot emit bitvector literal{indentD e}\nof bitwidth 0"
-    return mkLit w 0
-  | e@(app (app (const ``BitVec.ofNat _) w) n) => do
-    let w ← reduceWidth w e
-    let n ← reduceLit n e
-    if w == 0 then throwError "cannot emit bitvector literal{indentD e}\nof bitwidth 0"
-    return mkLit w n
+  | e@(app (app (const ``BitVec.repeat_ _) _) i) => do
+    let i ← reduceLit i e
+    return mkApp2 (symbolT "_") (symbolT "repeat") (literalT (toString i))
+  | e@(app (app (const ``BitVec.zeroExtend _) _) i) => do
+    let i ← reduceLit i e
+    return mkApp2 (symbolT "_") (symbolT "zero_extend") (literalT (toString i))
+  | e@(app (app (const ``BitVec.signExtend _) _) i) => do
+    let i ← reduceLit i e
+    return mkApp2 (symbolT "_") (symbolT "sign_extend") (literalT (toString i))
   | _ => return none
 where
   reduceWidth (w : Expr) (e : Expr) : TranslationM Nat := do

--- a/Smt/Data/BitVec.lean
+++ b/Smt/Data/BitVec.lean
@@ -7,16 +7,22 @@ Authors: Joe Hendrix, Wojciech Nawrocki
 
 /-!
 We define bitvectors. We choose the `Fin` representation over others for its relative efficiency
-(`Nat`s reduce in the kernel via GMP), alignment with `UIntXY` types which are also represented
+(Lean has special support for `Nat`), alignment with `UIntXY` types which are also represented
 with `Fin`, and the fact that bitwise operations on `Fin` are already defined. Some other possible
 representations are `List Bool`, `{ l : List Bool // l.length = w}`, `Fin w → Bool`.
 
+We also define many bitvector operations from the
+[`QF_BV` logic](https://smtlib.cs.uiowa.edu/logics-all.shtml#QF_BV).
+of SMT-LIBv2.
+
 TODO(WN): This is planned to go into mathlib4 once we:
-  - prove the various bounds
+  - have sorry-free bound proofs
   - match the interface to what SMT-LIB provides
   - are otherwise happy with the API
 -/
 
+/-- A bitvector of the specified width. This is represented as the underlying `Nat` number
+in both the runtime and the kernel, inheriting all the special support for `Nat`. -/
 def BitVec (w : Nat) := Fin (2^w)
 
 instance : DecidableEq (BitVec w) :=
@@ -24,19 +30,46 @@ instance : DecidableEq (BitVec w) :=
 
 namespace BitVec
 
+theorem pow_two_gt_zero (w : Nat) : 2^w > 0 :=
+  Nat.pos_pow_of_pos _ (by decide)
+
 protected def zero (w : Nat) : BitVec w :=
-  ⟨0, Nat.pos_pow_of_pos _ <| by decide⟩
+  ⟨0, pow_two_gt_zero w⟩
+
+/-- The bitvector `n mod 2^w`. -/
+protected def ofNat (w : Nat) (n : Nat) : BitVec w :=
+  Fin.ofNat' n (pow_two_gt_zero w)
 
 instance : Inhabited (BitVec w) := ⟨BitVec.zero w⟩
 
 instance : OfNat (BitVec w) (nat_lit 0) :=
   ⟨BitVec.zero w⟩
 
-protected def ofNat (w : Nat) (n : Nat) : BitVec w :=
-  Fin.ofNat' n (Nat.pos_pow_of_pos _ <| by decide)
+-- We inherit `Fin` implementations when fast but 
+protected def add (x y : BitVec w) : BitVec w := Fin.add x y
+protected def sub (x y : BitVec w) : BitVec w := Fin.sub x y
+protected def mul (x y : BitVec w) : BitVec w := Fin.mul x y
 
-protected def append (x : BitVec w) (y : BitVec v) : BitVec (w+v) :=
-  ⟨x.val <<< v ||| y.val, sorry⟩
+protected def mod (x y : BitVec w) : BitVec w :=
+  ⟨x.val % y.val, Nat.lt_of_le_of_lt (Nat.mod_le _ _) x.isLt⟩
+protected def div (x y : BitVec w) : BitVec w :=
+  ⟨x.val / y.val, Nat.lt_of_le_of_lt (Nat.div_le_self _ _) x.isLt⟩
+
+protected def lt (x y : BitVec w) : Bool :=
+  x.val < y.val
+protected def le (x y : BitVec w) : Bool :=
+  x.val ≤ y.val
+
+instance : Add (BitVec w) := ⟨BitVec.add⟩
+instance : Sub (BitVec w) := ⟨BitVec.sub⟩
+instance : Mul (BitVec w) := ⟨BitVec.mul⟩
+instance : Mod (BitVec w) := ⟨BitVec.mod⟩
+instance : Div (BitVec w) := ⟨BitVec.div⟩
+instance : LT (BitVec w)  := ⟨fun x y => BitVec.lt x y⟩
+instance : LE (BitVec w)  := ⟨fun x y => BitVec.le x y⟩
+
+protected def complement (x : BitVec w) : BitVec w :=
+  0 - (x + .ofNat w 1)
 
 protected def and (x y : BitVec w) : BitVec w :=
   ⟨x.val &&& y.val, sorry⟩
@@ -48,24 +81,47 @@ protected def xor (x y : BitVec w) : BitVec w :=
   ⟨x.val ^^^ y.val, sorry⟩
 
 protected def shiftLeft (x : BitVec w) (n : Nat) : BitVec w :=
-  Fin.ofNat' (x.val <<< n) (Nat.pos_pow_of_pos _ (by decide))
+  .ofNat w (x.val <<< n)
 
 protected def shiftRight (x : BitVec w) (n : Nat) : BitVec w :=
   ⟨x.val >>> n, sorry⟩
 
-instance : HAppend (BitVec w) (BitVec v) (BitVec (w+v)) := ⟨BitVec.append⟩
+instance : Complement (BitVec w) := ⟨BitVec.complement⟩
 instance : AndOp (BitVec w) := ⟨BitVec.and⟩
 instance : OrOp (BitVec w) := ⟨BitVec.or⟩
 instance : Xor (BitVec w) := ⟨BitVec.xor⟩
 instance : HShiftLeft (BitVec w) Nat (BitVec w) := ⟨BitVec.shiftLeft⟩
 instance : HShiftRight (BitVec w) Nat (BitVec w) := ⟨BitVec.shiftRight⟩
 
+def rotateLeft (x : BitVec w) (n : Nat) : BitVec w :=
+  x <<< n ||| x >>> (w - n)
+
+def rotateRight (x : BitVec w) (n : Nat) : BitVec w :=
+  x >>> n ||| x <<< (w - n)
+
+protected def append (x : BitVec w) (y : BitVec v) : BitVec (w+v) :=
+  ⟨x.val <<< v ||| y.val, sorry⟩
+
+instance : HAppend (BitVec w) (BitVec v) (BitVec (w+v)) := ⟨BitVec.append⟩
+
 def extract (i j : Nat) (x : BitVec w) : BitVec (i - j + 1) :=
   BitVec.ofNat _ (x.val >>> j)
 
-def zeroExtend (v : Nat) (x : BitVec w) (h : w ≤ v) : BitVec v :=
-  have hEq : v - w + w = v := Nat.sub_add_cancel h
-  hEq ▸ ((0 : BitVec (v - w)) ++ x)
+def repeat_ : (i : Nat) → BitVec w → BitVec (w*i)
+  | 0,   _ => 0
+  | n+1, x =>
+    have hEq : w + w*n = w*(n + 1) := by
+      rw [Nat.mul_add, Nat.add_comm, Nat.mul_one]
+    hEq ▸ (x ++ repeat_ n x)
+
+def zeroExtend (i : Nat) (x : BitVec w) : BitVec (w+i) :=
+  have hEq : w+i = i+w := Nat.add_comm _ _
+  hEq ▸ ((0 : BitVec i) ++ x)
+
+def signExtend (i : Nat) (x : BitVec w) : BitVec (w+i) :=
+  have hEq : ((w-1) - (w-1) + 1)*i + w = w+i := by
+    rw [Nat.sub_self, Nat.zero_add, Nat.one_mul, Nat.add_comm]
+  hEq ▸ ((repeat_ i (extract (w-1) (w-1) x)) ++ x)
 
 -- `prefix` may be a better name
 def shrink (v : Nat) (x : BitVec w) : BitVec v :=

--- a/Smt/Data/BitVec.lean
+++ b/Smt/Data/BitVec.lean
@@ -45,7 +45,8 @@ instance : Inhabited (BitVec w) := ⟨BitVec.zero w⟩
 instance : OfNat (BitVec w) (nat_lit 0) :=
   ⟨BitVec.zero w⟩
 
--- We inherit `Fin` implementations when fast but 
+-- We inherit `Fin` implementations when fast but write mod/div
+-- ourselves to avoid the extra modulo operation.
 protected def add (x y : BitVec w) : BitVec w := Fin.add x y
 protected def sub (x y : BitVec w) : BitVec w := Fin.sub x y
 protected def mul (x y : BitVec w) : BitVec w := Fin.mul x y

--- a/Test/BitVec/Shift.expected
+++ b/Test/BitVec/Shift.expected
@@ -1,20 +1,20 @@
-goal: x ++ y = (0 ++ x) <<< 2 ||| 0 ++ y
+goal: x ++ y = BitVec.zeroExtend 2 x <<< 2 ||| BitVec.zeroExtend 2 y
 
 query:
 (declare-const x (_ BitVec 2))
 (declare-const y (_ BitVec 2))
-(assert (not (= (concat x y) (bvor (bvshl (concat #b00 x) #b0010) (concat #b00 y)))))
+(assert (not (= (concat x y) (bvor (bvshl ((_ zero_extend 2) x) #b0010) ((_ zero_extend 2) y)))))
 (check-sat)
 
 result: unsat
 Test/BitVec/Shift.lean:4:8: warning: declaration uses 'sorry'
-goal: x ++ y = (0 ++ x) <<< 3 ||| 0 ++ y
+goal: x ++ y = BitVec.zeroExtend 3 x <<< 3 ||| BitVec.zeroExtend 3 y
 
 query:
 (declare-const x (_ BitVec 3))
 (declare-const y (_ BitVec 3))
-(assert (not (= (concat x y) (bvor (bvshl (concat #b000 x) #b000011) (concat #b000 y)))))
+(assert (not (= (concat x y) (bvor (bvshl ((_ zero_extend 3) x) #b000011) ((_ zero_extend 3) y)))))
 (check-sat)
 
 result: unsat
-Test/BitVec/Shift.lean:10:8: warning: declaration uses 'sorry'
+Test/BitVec/Shift.lean:9:8: warning: declaration uses 'sorry'

--- a/Test/BitVec/Shift.lean
+++ b/Test/BitVec/Shift.lean
@@ -2,13 +2,11 @@ import Smt
 import Smt.Data.BitVec
 
 theorem append_eq_shl_or_2 (x y : BitVec 2)
-    : x ++ y = (x.zeroExtend 4 (by decide) <<< 2) ||| y.zeroExtend 4 (by decide) := by
-  simp only [BitVec.zeroExtend]
+    : x ++ y = (x.zeroExtend 2 <<< 2) ||| y.zeroExtend 2 := by
   smt
   sorry
 
 theorem append_eq_shl_or_3 (x y : BitVec 3)
-    : x ++ y = (x.zeroExtend 6 (by decide) <<< 3) ||| y.zeroExtend 6 (by decide) := by
-  simp only [BitVec.zeroExtend]
+    : x ++ y = (x.zeroExtend 3 <<< 3) ||| y.zeroExtend 3 := by
   smt
   sorry


### PR DESCRIPTION
Adds most of the symbols except for some derived ones which we can translate into the definition directly, and for signed operations since the semantics of the default `Fin` arithmetic in Lean is unsigned (we could add them later if needed). Closes #41.