### PR TITLE
Only track fvars needed by translation.

### DIFF
--- a/Smt/Translate/Prop.lean
+++ b/Smt/Translate/Prop.lean
@@ -36,6 +36,7 @@ open Translator Term
     Meta.withLocalDecl n bi t fun x => do
       let tmT ← applyTranslators! t
       let tmB ← applyTranslators! (b.instantiate #[x])
+      modify fun s => { s with depFVars := s.depFVars.erase x.fvarId! }
       return existsT n.toString tmT tmB
   | _ => return none
 

--- a/Smt/Translate/Query.lean
+++ b/Smt/Translate/Query.lean
@@ -47,13 +47,11 @@ def addDependency (e e' : Expr) : QueryBuilderM Unit :=
 /-- Translate an expression and compute its (non-SMT-builtin) dependencies.
 When `fvarDeps = false`, we filter out dependencies on fvars. -/
 def translateAndFindDeps (e : Expr) (fvarDeps := true) : QueryBuilderM (Term × Array Expr) := do
-  let (tm, deps) ← Translator.translateExpr e
-  let unknownConsts := deps.toArray.filterMap fun nm =>
+  let (tm, depConsts, depFVars) ← Translator.translateExpr e
+  let unknownConsts := depConsts.toArray.filterMap fun nm =>
     if Util.smtConsts.contains nm.toString then none else some (mkConst nm)
   if fvarDeps then
-    let st : CollectFVars.State := {}
-    let st := collectFVars st e
-    let fvs := st.fvarIds.map mkFVar
+    let fvs := depFVars.toArray.map mkFVar
     return (tm, fvs ++ unknownConsts)
   else
     return (tm, unknownConsts)

--- a/Test/BitVec/XorComm.expected
+++ b/Test/BitVec/XorComm.expected
@@ -9,8 +9,8 @@ Test/BitVec/XorComm.lean:3:8: warning: declaration uses 'sorry'
 goal: x ^^^ y = y ^^^ x
 
 query:
-(declare-const y (_ BitVec 8))
 (declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
 (assert (distinct (bvxor x y) (bvxor y x)))
 (check-sat)
 Test/BitVec/XorComm.lean:7:8: warning: declaration uses 'sorry'

--- a/Test/Bool/Cong.expected
+++ b/Test/Bool/Cong.expected
@@ -1,8 +1,8 @@
 goal: (p == q) = true → (f p == f q) = true
 
 query:
-(declare-const p Bool)
 (declare-const q Bool)
+(declare-const p Bool)
 (declare-fun f (Bool) Bool)
 (assert (not (=> (= (= p q) true) (= (= (f p) (f q)) true))))
 (check-sat)

--- a/Test/Bool/Trans.expected
+++ b/Test/Bool/Trans.expected
@@ -2,7 +2,7 @@ goal: (p == q) = true → (q == r) = true → (p == r) = true
 
 query:
 (declare-const q Bool)
-(declare-const p Bool)
 (declare-const r Bool)
+(declare-const p Bool)
 (assert (not (=> (= (= p q) true) (=> (= (= q r) true) (= (= p r) true)))))
 (check-sat)

--- a/Test/Int/Binders.expected
+++ b/Test/Int/Binders.expected
@@ -29,8 +29,8 @@ goal: mismatchNamesAdd a b = mismatchNamesAdd b a
 
 query:
 (define-fun mismatchNamesAdd ((a Int) (b Int)) Int (+ a b))
-(declare-const b Int)
 (declare-const a Int)
+(declare-const b Int)
 (assert (distinct (mismatchNamesAdd a b) (mismatchNamesAdd b a)))
 (check-sat)
 Test/Int/Binders.lean:25:0: warning: declaration uses 'sorry'

--- a/Test/Nat/Cong.expected
+++ b/Test/Nat/Cong.expected
@@ -3,7 +3,7 @@ goal: x = y → f x = f y
 query:
 (define-sort Nat () Int)
 (declare-fun f (Nat) Nat)
-(assert (forall ((_uniq.1099 Nat)) (=> (>= _uniq.1099 0) (>= (f _uniq.1099) 0))))
+(assert (forall ((_uniq.1765 Nat)) (=> (>= _uniq.1765 0) (>= (f _uniq.1765) 0))))
 (declare-const x Nat)
 (assert (>= x 0))
 (declare-const y Nat)

--- a/Test/Nat/Max.expected
+++ b/Test/Nat/Max.expected
@@ -3,7 +3,7 @@ goal: x ≤ max' x y ∧ y ≤ max' x y
 query:
 (define-sort Nat () Int)
 (declare-fun |Nat.max'| (Nat Nat) Nat)
-(assert (forall ((_uniq.1345 Nat)) (=> (>= _uniq.1345 0) (forall ((_uniq.1346 Nat)) (=> (>= _uniq.1346 0) (>= (|Nat.max'| _uniq.1345 _uniq.1346) 0))))))
+(assert (forall ((_uniq.2574 Nat)) (=> (>= _uniq.2574 0) (forall ((_uniq.2575 Nat)) (=> (>= _uniq.2575 0) (>= (|Nat.max'| _uniq.2574 _uniq.2575) 0))))))
 (declare-const y Nat)
 (assert (>= y 0))
 (declare-const x Nat)
@@ -15,10 +15,10 @@ goal: x ≤ max' x y ∧ y ≤ max' x y
 query:
 (define-sort Nat () Int)
 (define-fun |Nat.max'| ((x Nat) (y Nat)) Nat (ite (<= x y) y x))
-(assert (forall ((_uniq.3382 Nat)) (=> (>= _uniq.3382 0) (forall ((_uniq.3383 Nat)) (=> (>= _uniq.3383 0) (>= (|Nat.max'| _uniq.3382 _uniq.3383) 0))))))
-(declare-const y Nat)
-(assert (>= y 0))
+(assert (forall ((_uniq.6062 Nat)) (=> (>= _uniq.6062 0) (forall ((_uniq.6063 Nat)) (=> (>= _uniq.6063 0) (>= (|Nat.max'| _uniq.6062 _uniq.6063) 0))))))
 (declare-const x Nat)
 (assert (>= x 0))
+(declare-const y Nat)
+(assert (>= y 0))
 (assert (not (and (<= x (|Nat.max'| x y)) (<= y (|Nat.max'| x y)))))
 (check-sat)

--- a/Test/Nat/Sum'.expected
+++ b/Test/Nat/Sum'.expected
@@ -6,7 +6,7 @@ query:
 (declare-const n Nat)
 (assert (>= n 0))
 (define-fun-rec sum ((n Nat)) Nat (ite (= n 0) 0 (+ n (sum (ite (<= 1 n) (- n 1) 0)))))
-(assert (forall ((_uniq.22096 Nat)) (=> (>= _uniq.22096 0) (>= (sum _uniq.22096) 0))))
+(assert (forall ((_uniq.23999 Nat)) (=> (>= _uniq.23999 0) (>= (sum _uniq.23999) 0))))
 (assert (= (sum n) (div (* n (+ n 1)) 2)))
 (assert (distinct (sum (+ n 1)) (div (* (+ n 1) (+ (+ n 1) 1)) 2)))
 (check-sat)

--- a/Test/linarith.expected
+++ b/Test/linarith.expected
@@ -14,5 +14,6 @@ Test/linarith.lean:117:13: warning: unused variable `c` [linter.unusedVariables]
 Test/linarith.lean:129:60: warning: unused variable `h3` [linter.unusedVariables]
 Test/linarith.lean:136:9: warning: unused variable `a` [linter.unusedVariables]
 Test/linarith.lean:136:13: warning: unused variable `c` [linter.unusedVariables]
+Test/linarith.lean:157:2: error: [arithPolyNorm]: could not prove x - y = -x + y
 Test/linarith.lean:179:34: warning: unused variable `z` [linter.unusedVariables]
 Test/linarith.lean:180:5: warning: unused variable `h5` [linter.unusedVariables]


### PR DESCRIPTION
Only translate free variables encountered during translation. If an expression contains a free variable not needed for translation, we skip it. This, unfortunately, requires disabling of the caching infrastructure to properly handle free variables introduced by quantifiers.

Fixes issue #97.