### PR TITLE
Update name of getLsb_cons to getLsbD_cons

### DIFF
--- a/Smt/Reconstruct/BitVec.lean
+++ b/Smt/Reconstruct/BitVec.lean
@@ -274,7 +274,7 @@ def reconstructRewrite (pf : cvc5.Proof) : ReconstructM (Option Expr) := do
       let h : Q(decide (BitVec.beq $x $y) = decide $p) ← Meta.mkFreshExprMVar q(decide (BitVec.beq $x $y) = @decide $p $hp)
       let mv ← Bool.boolify h.mvarId!
       let ds := [``BitVec.beq, ``BitVec.beq.go]
-      let ts := [``BitVec.getLsb_cons, ``Nat.succ.injEq]
+      let ts := [``BitVec.getLsbD_cons, ``Nat.succ.injEq]
       let ps := [``Nat.reduceAdd, ``Nat.reduceSub, ``Nat.reduceEqDiff, ``reduceIte]
       let simpTheorems ← ds.foldrM (fun n a => a.addDeclToUnfold n) {}
       let simpTheorems ← ts.foldrM (fun n a => a.addConst n) simpTheorems
@@ -290,7 +290,7 @@ def reconstructRewrite (pf : cvc5.Proof) : ReconstructM (Option Expr) := do
       let h : Q((BitVec.adc' $x $y false).snd = $z) ← Meta.mkFreshExprMVar q((BitVec.adc' $x $y false).snd = $z)
       let mv ← Bool.boolify h.mvarId!
       let ds := [``BitVec.adc', ``BitVec.adcb', ``BitVec.iunfoldr, ``Fin.hIterate, ``Fin.hIterateFrom]
-      let ts := [``BitVec.getLsb_cons, ``Nat.succ.injEq]
+      let ts := [``BitVec.getLsbD_cons, ``Nat.succ.injEq]
       let ps := [``Nat.reduceAdd, ``Nat.reduceLT, ``reduceDIte, ``reduceIte]
       let simpTheorems ← ds.foldrM (fun n a => a.addDeclToUnfold n) {}
       let simpTheorems ← ts.foldrM (fun n a => a.addConst n) simpTheorems


### PR DESCRIPTION
In the update from 4.11 to 4.12 the theorem `getLsb_cons` had its name changed to `getLsbD_cons`, which was making the build fail. Reading [this comment](https://github.com/leanprover/lean4/blob/master/src/Init/Data/BitVec/Basic.lean#L74) it seems that maybe it will be changed back in the future, but for now this change is necessary for building.