### PR TITLE
Stop using quote4 in pattern-matching to improve performance.

### DIFF
--- a/Smt/Recognizers.lean
+++ b/Smt/Recognizers.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2021-2025 by the authors listed in the file AUTHORS and their
+institutional affiliations. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Abdalrhman Mohamed
+-/
+
+import Lean.Meta.Basic
+import Lean.Util.Recognizers
+
+namespace Lean.Expr
+
+def app5? (e : Expr) (fName : Name) : Option (Expr × Expr × Expr × Expr × Expr) :=
+  if e.isAppOfArity fName 5 then
+    some (e.appFn!.appFn!.appFn!.appFn!.appArg!, e.appFn!.appFn!.appFn!.appArg!, e.appFn!.appFn!.appArg!, e.appFn!.appArg!, e.appArg!)
+  else
+    none
+
+def or? (p : Expr) : Option (Expr × Expr) :=
+  p.app2? ``Or
+
+def imp? (p : Expr) : Lean.MetaM (Option (Expr × Expr)) := do
+  let .forallE _ p q _ := p | return none
+  if ← (isAProp p) <&&> (isAProp q) then
+    return (p, q)
+  else
+    return none
+where
+  isAProp (e : Expr) : MetaM Bool := do
+    return (← Meta.inferType e).isProp
+
+def beq? (b : Expr) : Option (Expr × Expr × Expr) :=
+  let_expr BEq.beq α _ a b := b | none
+  return (α, a, b)
+
+def bne? (b : Expr) : Option (Expr × Expr × Expr) :=
+  let_expr bne α _ a b := b | none
+  return (α, a, b)
+
+def ltOf? (e : Expr) (α : Expr) : Option (Expr × Expr) :=
+  let_expr LT.lt β _ x y := e | none
+  if β == α then
+    return (x, y)
+  else
+    none
+
+def leOf? (e : Expr) (α : Expr) : Option (Expr × Expr) :=
+  let_expr LE.le β _ x y := e | none
+  if β == α then
+    return (x, y)
+  else
+    none
+
+def geOf? (e : Expr) (α : Expr) : Option (Expr × Expr) :=
+  let_expr GE.ge β _ x y := e | none
+  if β == α then
+    return (x, y)
+  else
+    none
+
+def gtOf? (e : Expr) (α : Expr) : Option (Expr × Expr) :=
+  let_expr GT.gt β _ x y := e | none
+  if β == α then
+    return (x, y)
+  else
+    none
+
+def natLitOf? (e : Expr) (α : Expr) : Option Nat :=
+  let_expr OfNat.ofNat β n _ := e | none
+  if β == α then
+    n.rawNatLit?
+  else
+    none
+
+def intCastOf? (e : Expr) (α : Expr) : Option Expr :=
+  let_expr Int.cast β _ x := e | none
+  if β == α then
+    return x
+  else
+    none
+
+def intFloorOf? (e : Expr) (α : Expr) : Option Expr := do
+  let some (β, _, _, _, x) := e.app5? `Int.floor | none
+  if β == α then
+    return x
+  else
+    none
+
+def negOf? (e : Expr) (α : Expr) : Option Expr :=
+  let_expr Neg.neg β _ x := e | none
+  if β == α then
+    return x
+  else
+    none
+
+def absOf? (e : Lean.Expr) (α : Expr) : Option Expr := do
+  let some (β, _, _, x) := e.app4? `abs | none
+  if β == α then
+    return x
+  else
+    none
+
+def hAddOf? (e : Expr) (α : Expr) (β : Expr) : Option (Expr × Expr) :=
+  let_expr HAdd.hAdd γ δ _ _ x y := e | none
+  if γ == α && δ == β then
+    return (x, y)
+  else
+    none
+
+def hSubOf? (e : Expr) (α : Expr) (β : Expr) : Option (Expr × Expr) :=
+  let_expr HSub.hSub γ δ _ _ x y := e | none
+  if γ == α && δ == β then
+    return (x, y)
+  else
+    none
+
+def hMulOf? (e : Expr) (α : Expr) (β : Expr) : Option (Expr × Expr) :=
+  let_expr HMul.hMul γ δ _ _ x y := e | none
+  if γ == α && δ == β then
+    return (x, y)
+  else
+    none
+
+def hDivOf? (e : Expr) (α : Expr) (β : Expr) : Option (Expr × Expr) :=
+  let_expr HDiv.hDiv γ δ _ _ x y := e | none
+  if γ == α && δ == β then
+    return (x, y)
+  else
+    none
+
+def hModOf? (e : Expr) (α : Expr) (β : Expr) : Option (Expr × Expr) :=
+  let_expr HMod.hMod γ δ _ _ x y := e | none
+  if γ == α && δ == β then
+    return (x, y)
+  else
+    none
+
+def hPowOf? (e : Expr) (α : Expr) (β : Expr) : Option (Expr × Expr) :=
+  let_expr HPow.hPow γ δ _ _ x y := e | none
+  if γ == α && δ == β then
+    return (x, y)
+  else
+    none
+
+def hAndOf? (e : Expr) (α : Expr) (β : Expr) : Option (Expr × Expr) :=
+  let_expr HAnd.hAnd γ δ _ _ x y := e | none
+  if γ == α && δ == β then
+    return (x, y)
+  else
+    none
+
+def hOrOf? (e : Expr) (α : Expr) (β : Expr) : Option (Expr × Expr) :=
+  let_expr HOr.hOr γ δ _ _ x y := e | none
+  if γ == α && δ == β then
+    return (x, y)
+  else
+    none
+
+def hXorOf? (e : Expr) (α : Expr) (β : Expr) : Option (Expr × Expr) :=
+  let_expr HXor.hXor γ δ _ _ x y := e | none
+  if γ == α && δ == β then
+    return (x, y)
+  else
+    none
+
+def hAppendOf? (e : Expr) (α : Expr) (β : Expr) : Option (Expr × Expr) :=
+  let_expr HAppend.hAppend γ δ _ _ x y := e | none
+  if γ == α && δ == β then
+    return (x, y)
+  else
+    none
+
+end Lean.Expr

--- a/Smt/Translate/BitVec.lean
+++ b/Smt/Translate/BitVec.lean
@@ -5,107 +5,147 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Wojciech Nawrocki
 -/
 
-import Qq
-
+import Smt.Recognizers
 import Smt.Translate
 
 namespace Smt.Translate.BitVec
 
 open Lean Expr
-open Qq
 open Translator Term
 
-def getWidth (e : Expr) : MetaM (Option Nat) := do
-  let t : Q(Type) ← Meta.inferType e
-  match t with
-  | ~q(BitVec $w) => Meta.evalNat (← Meta.whnf w)
-  | _             => return none
-
 /-- Make a binary bitvector literal with value `n` and width `w`. -/
-def mkLit (w : Nat) (n : Nat) : Term :=
+private def mkLit (w : Nat) (n : Nat) : Term :=
   let bits := Nat.toDigits 2 n |>.take w
   literalT <| bits.foldl (init := "#b".pushn '0' (w - bits.length)) (·.push ·)
 
-def reduceLit (n : Expr) (e : Expr) : TranslationM Nat := do
-  let some n ← Meta.evalNat (← Meta.whnf n) |>.run
-    | throwError "literal{indentD n}\nis not constant in{indentD e}"
+private def reduceLit (n : Expr) (e : Expr) : TranslationM Nat := do
+  let some n ← (Meta.evalNat (← Meta.whnf n)).run | throwError "literal{indentD n}\nis not constant in{indentD e}"
   return n
 
-def reduceWidth (w : Expr) (e : Expr) : TranslationM Nat := do
-  let some w ← Meta.evalNat (← Meta.whnf w) |>.run
-    | throwError "bitvector width{indentD w}\nis not constant in{indentD e}"
-  return w
+private def reduceWidth (w : Expr) (e : Expr) : TranslationM Nat := do
+  let some w' ← (Meta.evalNat w).run | throwError "bitvector width{indentD w}\nis not constant in{indentD e}"
+  if w' == 0 then
+    throwError "bitvector width{indentD w}\nis 0 in{indentD e}"
+  return w'
 
-@[smt_translate] def translateType : Translator := fun (e : Q(Type)) => match e with
-  | ~q(BitVec $w) => do
-    let w ← Meta.whnf w
-    let some w ← (Meta.evalNat w).run
-      | throwError "bitvector type{indentD e}\nhas variable width"
+private def reduceBitVecWidth? (e : Expr) : MetaM (Option Nat) := do
+  let some w := e.app1? ``BitVec | return none
+  let some w' ← (Meta.evalNat w).run | throwError "bitvector type{indentD e}\nhas variable width"
+  if w' == 0 then
+    throwError "bitvector width{indentD w}\nis 0 in{indentD e}"
+  return w'
+
+@[smt_translate] def translateType : Translator := fun e => do
+  if let some w ← reduceBitVecWidth? e then
     return mkApp2 (symbolT "_") (symbolT "BitVec") (literalT (toString w))
-  | _             => return none
+  else
+    return none
 
-open BitVec in
-@[smt_translate] def translateBitVec : Translator := fun e => do
-  let some w ← getWidth e | return none
-  let e : Q(BitVec $w) ← pure e
-  match e with
-  | ~q(@HShiftLeft.hShiftLeft (BitVec _) (BitVec _) _ _ $x $y)   =>
-    return mkApp2 (symbolT "bvshl") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(@HShiftRight.hShiftRight (BitVec _) (BitVec _) _ _ $x $y) =>
-    return mkApp2 (symbolT "bvlshr") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(@BitVec.zeroExtend $v _ $x) =>
+@[smt_translate] def translateBitVec : Translator := fun e => do match_expr e with
+  | HShiftLeft.hShiftLeft α β _ _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    let some _ ← reduceBitVecWidth? β | return none
+    return some (mkApp2 (symbolT "bvshl") (← applyTranslators! x) (← applyTranslators! y))
+  | HShiftRight.hShiftRight α β _ _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    let some _ ← reduceBitVecWidth? β | return none
+    return some (mkApp2 (symbolT "bvlshr") (← applyTranslators! x) (← applyTranslators! y))
+  | BitVec.zeroExtend w v x =>
+    let w ← reduceWidth w x
     let v ← reduceWidth v e
-    return mkApp3 (symbolT "_") (symbolT "zero_extend") (literalT (toString (w - v))) (← applyTranslators! x)
-  | ~q(@BitVec.signExtend $v _ $x) =>
+    return some (mkApp3 (symbolT "_") (symbolT "zero_extend") (literalT (toString (v - w))) (← applyTranslators! x))
+  | BitVec.signExtend w v x =>
+    let w ← reduceWidth w x
     let v ← reduceWidth v e
-    return mkApp3 (symbolT "_") (symbolT "sign_extend") (literalT (toString (w - v))) (← applyTranslators! x)
-  | ~q(.ofNat _ $n)    => return mkLit w (← reduceLit n e)
-  | ~q(OfNat.ofNat $n) => return mkLit w (← reduceLit n e)
-  | ~q(-$x)            => return appT (symbolT "bvneg") (← applyTranslators! x)
-  | ~q(~~~$x)          => return appT (symbolT "bvnot") (← applyTranslators! x)
-  | ~q($x + $y)        => return mkApp2 (symbolT "bvadd") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x - $y)        => return mkApp2 (symbolT "bvsub") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x * $y)        => return mkApp2 (symbolT "bvmul") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(.smtUDiv $x $y) => return mkApp2 (symbolT "bvudiv") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x % $y)        => return mkApp2 (symbolT "bvurem") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(.smtSDiv $x $y) => return mkApp2 (symbolT "bvsdiv") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(.srem $x $y)    => return mkApp2 (symbolT "bvsrem") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(.smod $x $y)    => return mkApp2 (symbolT "bvsmod") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x &&& $y)      => return mkApp2 (symbolT "bvand") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x ||| $y)      => return mkApp2 (symbolT "bvor") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x ^^^ $y)      => return mkApp2 (symbolT "bvxor") (← applyTranslators! x) (← applyTranslators! y)
+    return some (mkApp3 (symbolT "_") (symbolT "sign_extend") (literalT (toString (v - w))) (← applyTranslators! x))
+  | BitVec.ofNat w n =>
+    let w ← reduceWidth w e
+    let n ← reduceLit n e
+    return some (mkLit w n)
+  | OfNat.ofNat α n _ =>
+    let some w ← reduceBitVecWidth? α | return none
+    let n ← reduceLit n e
+    return some (mkLit w n)
+  | Neg.neg α _ x =>
+    let some _ ← reduceBitVecWidth? α | return none
+    return some (appT (symbolT "bvneg") (← applyTranslators! x))
+  | Complement.complement α _ x =>
+    let some _ ← reduceBitVecWidth? α | return none
+    return some (appT (symbolT "bvnot") (← applyTranslators! x))
+  | HAdd.hAdd α β _ _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    let some _ ← reduceBitVecWidth? β | return none
+    return some (mkApp2 (symbolT "bvadd") (← applyTranslators! x) (← applyTranslators! y))
+  | HSub.hSub α β _ _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    let some _ ← reduceBitVecWidth? β | return none
+    return some (mkApp2 (symbolT "bvsub") (← applyTranslators! x) (← applyTranslators! y))
+  | HMul.hMul α β _ _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    let some _ ← reduceBitVecWidth? β | return none
+    return some (mkApp2 (symbolT "bvmul") (← applyTranslators! x) (← applyTranslators! y))
+  | BitVec.smtUDiv _ x y =>
+    return some (mkApp2 (symbolT "bvudiv") (← applyTranslators! x) (← applyTranslators! y))
+  | HMod.hMod α β _ _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    let some _ ← reduceBitVecWidth? β | return none
+    return some (mkApp2 (symbolT "bvurem") (← applyTranslators! x) (← applyTranslators! y))
+  | BitVec.smtSDiv w x y =>
+    _ ← reduceWidth w e
+    return some (mkApp2 (symbolT "bvsdiv") (← applyTranslators! x) (← applyTranslators! y))
+  | BitVec.srem w x y =>
+    _ ← reduceWidth w e
+    return some (mkApp2 (symbolT "bvsrem") (← applyTranslators! x) (← applyTranslators! y))
+  | BitVec.smod w x y =>
+    _ ← reduceWidth w e
+    return some (mkApp2 (symbolT "bvsmod") (← applyTranslators! x) (← applyTranslators! y))
+  | HAnd.hAnd α β _ _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    let some _ ← reduceBitVecWidth? β | return none
+    return some (mkApp2 (symbolT "bvand") (← applyTranslators! x) (← applyTranslators! y))
+  | HOr.hOr α β _ _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    let some _ ← reduceBitVecWidth? β | return none
+    return some (mkApp2 (symbolT "bvor") (← applyTranslators! x) (← applyTranslators! y))
+  | HXor.hXor α β _ _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    let some _ ← reduceBitVecWidth? β | return none
+    return some (mkApp2 (symbolT "bvxor") (← applyTranslators! x) (← applyTranslators! y))
+  | BitVec.zero w => do
+    let w ← reduceWidth w e
+    return mkLit w 0
+  | BitVec.rotateLeft w x n =>
+    _ ← reduceWidth w e
+    return appT (mkApp2 (symbolT "_") (symbolT "rotate_left") (literalT (toString n)))
+                (← applyTranslators! x)
+  | BitVec.rotateRight w x n =>
+    _ ← reduceWidth w e
+    return appT (mkApp2 (symbolT "_") (symbolT "rotate_right") (literalT (toString n)))
+                (← applyTranslators! x)
+  | HAppend.hAppend α β _ _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    let some _ ← reduceBitVecWidth? β | return none
+    return some (mkApp2 (symbolT "concat") (← applyTranslators! x) (← applyTranslators! y))
+  | BitVec.replicate w i x =>
+    _ ← reduceWidth w e
+    let i ← reduceLit i e
+    return appT (mkApp2 (symbolT "_") (symbolT "repeat") (literalT (toString i)))
+                (← applyTranslators! x)
   | _                  => return none
 
-@[smt_translate] def translateProp : Translator := fun (e : Q(Prop)) => match e with
-  | ~q(($x : BitVec _) < $y) => return mkApp2 (symbolT "bvult") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : BitVec _) ≤ $y) => return mkApp2 (symbolT "bvule") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : BitVec _) ≥ $y) => return mkApp2 (symbolT "bvuge") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : BitVec _) > $y) => return mkApp2 (symbolT "bvugt") (← applyTranslators! x) (← applyTranslators! y)
+@[smt_translate] def translateProp : Translator := fun e => do match_expr e with
+  | LT.lt α _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    return some (mkApp2 (symbolT "bvult") (← applyTranslators! x) (← applyTranslators! y))
+  | LE.le α _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    return some (mkApp2 (symbolT "bvule") (← applyTranslators! x) (← applyTranslators! y))
+  | GE.ge α _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    return some (mkApp2 (symbolT "bvuge") (← applyTranslators! x) (← applyTranslators! y))
+  | GT.gt α _ x y =>
+    let some _ ← reduceBitVecWidth? α | return none
+    return some (mkApp2 (symbolT "bvugt") (← applyTranslators! x) (← applyTranslators! y))
   | _                        => return none
-
-@[smt_translate] def replaceFun : Translator
-  | e@(app (const ``BitVec.zero _) w) => do
-    let w ← reduceWidth w e
-    if w == 0 then throwError "cannot emit bitvector literal{indentD e}\nof bitwidth 0"
-    return mkLit w 0
-  | e@(app (app (app (const ``BitVec.rotateLeft _) _) x) n) => do
-    let n ← reduceLit n e
-    return appT
-      (mkApp2 (symbolT "_") (symbolT "rotate_left") (literalT (toString n)))
-      (← applyTranslators! x)
-  | e@(app (app (app (const ``BitVec.rotateRight _) _) x) n) => do
-    let n ← reduceLit n e
-    return appT
-      (mkApp2 (symbolT "_") (symbolT "rotate_right") (literalT (toString n)))
-      (← applyTranslators! x)
-  | app (app (app (app (const ``HAppend.hAppend _) (app (const ``BitVec _) _)) _) _) _ => return symbolT "concat"
-  | e@(app (app (app (const ``BitVec.extractLsb _) _) i) j) => do
-    let i ← reduceLit i e
-    let j ← reduceLit j e
-    return mkApp3 (symbolT "_") (symbolT "extract") (literalT (toString i)) (literalT (toString j))
-  | e@(app (app (const ``BitVec.replicate _) _) i) => do
-    let i ← reduceLit i e
-    return mkApp2 (symbolT "_") (symbolT "repeat") (literalT (toString i))
-  | _ => return none
 
 end Smt.Translate.BitVec

--- a/Smt/Translate/Int.lean
+++ b/Smt/Translate/Int.lean
@@ -5,34 +5,48 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed, Wojciech Nawrocki
 -/
 
-import Qq
-
+import Smt.Recognizers
 import Smt.Translate
 
 namespace Smt.Translate.Int
 
-open Qq
 open Translator Term
 
-@[smt_translate] def translateType : Translator := fun (e : Q(Type)) => match e with
-  | ~q(Int) => return symbolT "Int"
-  | _       => return none
+private def mkInt : Lean.Expr :=
+  .const ``Int []
 
-@[smt_translate] def translateInt : Translator := fun (e : Q(Int)) => match e with
-  | ~q(OfNat.ofNat $n) => return if let some n := n.rawNatLit? then literalT (toString n) else none
-  | ~q(-$x)     => return appT (symbolT "-") (← applyTranslators! x)
-  | ~q($x + $y) => return mkApp2 (symbolT "+") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x - $y) => return mkApp2 (symbolT "-") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x * $y) => return mkApp2 (symbolT "*") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x / $y) => return mkApp2 (symbolT "div") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x % $y) => return mkApp2 (symbolT "mod") (← applyTranslators! x) (← applyTranslators! y)
-  | _           => return none
+@[smt_translate] def translateType : Translator := fun e => match e with
+  | .const ``Int _ => return symbolT "Int"
+  | _              => return none
 
-@[smt_translate] def translateProp : Translator := fun (e : Q(Prop)) => match e with
-  | ~q(($x : Int) < $y) => return mkApp2 (symbolT "<") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : Int) ≤ $y) => return mkApp2 (symbolT "<=") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : Int) ≥ $y) => return mkApp2 (symbolT ">=") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : Int) > $y) => return mkApp2 (symbolT ">") (← applyTranslators! x) (← applyTranslators! y)
-  | _                   => return none
+@[smt_translate] def translateInt : Translator := fun e => do
+  if let some n := e.natLitOf? mkInt then
+    return literalT (toString n)
+  else if let some x := e.negOf? mkInt then
+    return appT (symbolT "-") (← applyTranslators! x)
+  else if let some (x, y) := e.hAddOf? mkInt mkInt then
+    return mkApp2 (symbolT "+") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.hSubOf? mkInt mkInt then
+    return mkApp2 (symbolT "-") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.hMulOf? mkInt mkInt then
+    return mkApp2 (symbolT "*") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.hDivOf? mkInt mkInt then
+    return mkApp2 (symbolT "div") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.hModOf? mkInt mkInt then
+    return mkApp2 (symbolT "mod") (← applyTranslators! x) (← applyTranslators! y)
+  else
+    return none
+
+@[smt_translate] def translateProp : Translator := fun e => do
+  if let some (x, y) := e.ltOf? mkInt then
+    return mkApp2 (symbolT "<") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.leOf? mkInt then
+    return mkApp2 (symbolT "<=") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.geOf? mkInt then
+    return mkApp2 (symbolT ">=") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.gtOf? mkInt then
+    return mkApp2 (symbolT ">") (← applyTranslators! x) (← applyTranslators! y)
+  else
+    return none
 
 end Smt.Translate.Int

--- a/Smt/Translate/Nat.lean
+++ b/Smt/Translate/Nat.lean
@@ -5,35 +5,50 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed, Wojciech Nawrocki
 -/
 
-import Qq
-
+import Smt.Recognizers
 import Smt.Translate
 
 namespace Smt.Translate.Nat
 
-open Qq
 open Lean Expr
 open Translator Term
 
-@[smt_translate] def translateNat : Translator := fun (e : Q(Nat)) => match e with
-  | ~q(OfNat.ofNat $n) => return if let some n := n.rawNatLit? then literalT (toString n) else none
-  | ~q(.zero)    => return literalT "0"
-  | ~q(.succ $n) => return mkApp2 (symbolT "+") (← applyTranslators! n) (literalT "1")
-  | ~q($n + $m)  => return mkApp2 (symbolT "+") (← applyTranslators! n) (← applyTranslators! m)
-  | ~q($n * $m)  => return mkApp2 (symbolT "*") (← applyTranslators! n) (← applyTranslators! m)
-  | ~q($n / $m)  => return mkApp2 (symbolT "div") (← applyTranslators! n) (← applyTranslators! m)
-  | ~q($n % $m)  => return mkApp2 (symbolT "mod") (← applyTranslators! n) (← applyTranslators! m)
-  | ~q($n - $m)  => return mkApp3 (symbolT "ite") (mkApp2 (symbolT "<=") (← applyTranslators! m) (← applyTranslators! n))
-                                                  (mkApp2 (symbolT "-") (← applyTranslators! n) (← applyTranslators! m))
-                                                  (literalT "0")
-  | _            => return none
+private def mkNat : Lean.Expr :=
+  .const ``Nat []
 
-@[smt_translate] def translateProp : Translator := fun (e : Q(Prop)) => match e with
-  | ~q(($n : Nat) < $m) => return mkApp2 (symbolT "<") (← applyTranslators! n) (← applyTranslators! m)
-  | ~q(($n : Nat) ≤ $m) => return mkApp2 (symbolT "<=") (← applyTranslators! n) (← applyTranslators! m)
-  | ~q(($n : Nat) ≥ $m) => return mkApp2 (symbolT ">=") (← applyTranslators! n) (← applyTranslators! m)
-  | ~q(($n : Nat) > $m) => return mkApp2 (symbolT ">") (← applyTranslators! n) (← applyTranslators! m)
-  | _                   => return none
+@[smt_translate] def translateNat : Translator := fun e => do
+  if let some n := e.natLitOf? mkNat then
+    return literalT (toString n)
+  else if let .const ``Nat.zero _ := e then
+    return literalT "0"
+  else if let some n := e.app1? ``Nat.succ then
+    return mkApp2 (symbolT "+") (← applyTranslators! n) (literalT "1")
+  else if let some (m, n) := e.hAddOf? mkNat mkNat then
+    return mkApp2 (symbolT "+") (← applyTranslators! m) (← applyTranslators! n)
+  else if let some (m, n) := e.hSubOf? mkNat mkNat then
+    return mkApp3 (symbolT "ite") (mkApp2 (symbolT "<=") (← applyTranslators! n) (← applyTranslators! m))
+                                  (mkApp2 (symbolT "-") (← applyTranslators! m) (← applyTranslators! n))
+                                  (literalT "0")
+  else if let some (m, n) := e.hMulOf? mkNat mkNat then
+    return mkApp2 (symbolT "*") (← applyTranslators! m) (← applyTranslators! n)
+  else if let some (m, n) := e.hDivOf? mkNat mkNat then
+    return mkApp2 (symbolT "div") (← applyTranslators! m) (← applyTranslators! n)
+  else if let some (m, n) := e.hModOf? mkNat mkNat then
+    return mkApp2 (symbolT "mod") (← applyTranslators! m) (← applyTranslators! n)
+  else
+    return none
+
+@[smt_translate] def translateProp : Translator := fun e => do
+  if let some (m, n) := e.ltOf? mkNat then
+    return mkApp2 (symbolT "<") (← applyTranslators! m) (← applyTranslators! n)
+  else if let some (m, n) := e.leOf? mkNat then
+    return mkApp2 (symbolT "<=") (← applyTranslators! m) (← applyTranslators! n)
+  else if let some (m, n) := e.geOf? mkNat then
+    return mkApp2 (symbolT ">=") (← applyTranslators! m) (← applyTranslators! n)
+  else if let some (m, n) := e.gtOf? mkNat then
+    return mkApp2 (symbolT ">") (← applyTranslators! m) (← applyTranslators! n)
+  else
+    return none
 
 /- Translates quantified expressions over natural numbers for with versions that
    ensure the quantified variables are greater than or equal to 0. For

--- a/Smt/Translate/Real.lean
+++ b/Smt/Translate/Real.lean
@@ -5,45 +5,58 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed
 -/
 
-import Qq
-
+import Smt.Recognizers
 import Mathlib.Data.Real.Archimedean
 
 import Smt.Translate
 
 namespace Smt.Translate.Rat
 
-open Qq
 open Translator Term
 
-@[smt_translate] def translateType : Translator := fun (e : Q(Type)) => match e with
-  | ~q(Real)  => return symbolT "Real"
-  | _         => return none
+private def mkReal : Lean.Expr :=
+  .const ``Real []
 
-@[smt_translate] def translateInt : Translator := fun (e : Q(Int)) => match e with
-  | ~q(⌊($x : Real)⌋) => return appT (symbolT "to_int") (← applyTranslators! x)
+@[smt_translate] def translateType : Translator := fun e => match e with
+  | .const ``Real _  => return symbolT "Real"
   | _                => return none
 
-@[smt_translate] def translateReal : Translator := fun (e : Q(Real)) => match e with
-  | ~q((($x : Int) : Real)) => return appT (symbolT "to_real") (← applyTranslators! x)
-  | ~q(@OfNat.ofNat _ _ (@instOfNatAtLeastTwo _ _ _ instNatAtLeastTwo)) =>
-    return if let some n := (e.getArg! 1).rawNatLit? then literalT s!"{n}.0" else none
-  | ~q(0)       => return (literalT "0.0")
-  | ~q(1)       => return (literalT "1.0")
-  | ~q(-$x)     => return appT (symbolT "-") (← applyTranslators! x)
-  | ~q(|$x|)     => return appT (symbolT "abs") (← applyTranslators! x)
-  | ~q($x + $y) => return mkApp2 (symbolT "+") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x - $y) => return mkApp2 (symbolT "-") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x * $y) => return mkApp2 (symbolT "*") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x / $y) => return mkApp2 (symbolT "/") (← applyTranslators! x) (← applyTranslators! y)
-  | _           => return none
+@[smt_translate] def translateInt : Translator := fun e => do
+  if let some x := e.intFloorOf? mkReal then
+    return appT (symbolT "to_int") (← applyTranslators! x)
+  else
+    return none
 
-@[smt_translate] def translateProp : Translator := fun (e : Q(Prop)) => match e with
-  | ~q(($x : Real) = ⌊$x⌋) => return appT (symbolT "is_int") (← applyTranslators! x)
-  | ~q(($x : Real) < $y) => return mkApp2 (symbolT "<") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : Real) ≤ $y) => return mkApp2 (symbolT "<=") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : Real) ≥ $y) => return mkApp2 (symbolT ">=") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : Real) > $y) => return mkApp2 (symbolT ">") (← applyTranslators! x) (← applyTranslators! y)
-  | _                    => return none
+@[smt_translate] def translateReal : Translator := fun e => do
+  if let some n := e.natLitOf? mkReal then
+    return literalT s!"{n}.0"
+  else if let some x := e.intCastOf? mkReal then
+    return appT (symbolT "to_real") (← applyTranslators! x)
+  else if let some x := e.negOf? mkReal then
+    return appT (symbolT "-") (← applyTranslators! x)
+  else if let some x := e.absOf? mkReal then
+    return appT (symbolT "abs") (← applyTranslators! x)
+  else if let some (x, y) := e.hAddOf? mkReal mkReal then
+    return mkApp2 (symbolT "+") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.hSubOf? mkReal mkReal then
+    return mkApp2 (symbolT "-") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.hMulOf? mkReal mkReal then
+    return mkApp2 (symbolT "*") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.hDivOf? mkReal mkReal then
+    return mkApp2 (symbolT "/") (← applyTranslators! x) (← applyTranslators! y)
+  else
+    return none
+
+@[smt_translate] def translateProp : Translator := fun e => do
+  if let some (x, y) := e.ltOf? mkReal then
+    return mkApp2 (symbolT "<") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.leOf? mkReal then
+    return mkApp2 (symbolT "<=") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.geOf? mkReal then
+    return mkApp2 (symbolT ">=") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.gtOf? mkReal then
+    return mkApp2 (symbolT ">") (← applyTranslators! x) (← applyTranslators! y)
+  else
+    return none
 
 end Smt.Translate.Rat

--- a/Smt/Translate/String.lean
+++ b/Smt/Translate/String.lean
@@ -5,34 +5,43 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed, Wojciech Nawrocki
 -/
 
-import Qq
-
+import Smt.Recognizers
 import Smt.Translate
 
 namespace Smt.Translate.String
 
-open Qq
 open Lean Expr
 open Translator Term
 
-@[smt_translate] def translateType : Translator := fun (e : Q(Type)) => match e with
-  | ~q(String) => return symbolT "String"
-  | _          => return none
+private def mkString : Expr :=
+  .const ``String []
 
-@[smt_translate] def translateInt : Translator := fun (e : Q(Int)) => match e with
-  | ~q(String.length $x) => return appT (symbolT "str.len") (← applyTranslators! x)
-  | _                    => return none
+@[smt_translate] def translateType : Translator := fun e => match e with
+  | .const ``String _ => return symbolT "String"
+  | _                 => return none
 
-@[smt_translate] def translateString : Translator := fun (e : Q(String)) => match e with
-  | ~q(.replace $z $x $y) => return mkApp3 (symbolT "str.replace_all") (← applyTranslators! z)
-                                           (← applyTranslators! x) (← applyTranslators! y)
-  | .lit (.strVal s) => return literalT s!"\"{s}\""
-  | ~q($x ++ $y)     => return mkApp2 (symbolT "str.++") (← applyTranslators! x) (← applyTranslators! y)
-  | _                => return none
+@[smt_translate] def translateInt : Translator := fun e => do
+  if let some s := e.app1? ``String.length then
+    return appT (symbolT "str.len") (← applyTranslators! s)
+  else
+    return none
 
-@[smt_translate] def translateProp : Translator := fun (e : Q(Prop)) => match e with
-  | ~q(($x : String) < $y) => return mkApp2 (symbolT "str.<") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : String) > $y) => return mkApp2 (symbolT "str.>") (← applyTranslators! x) (← applyTranslators! y)
-  | _                      => return none
+@[smt_translate] def translateString : Translator := fun e => do
+  if let .lit (.strVal s) := e then
+    return literalT s!"\"{s}\""
+  else if let some (z, x, y) := e.app3? ``String.replace then
+    return mkApp3 (symbolT "str.replace_all") (← applyTranslators! z) (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.hAppendOf? mkString mkString then
+    return mkApp2 (symbolT "str.++") (← applyTranslators! x) (← applyTranslators! y)
+  else
+    return none
+
+@[smt_translate] def translateProp : Translator := fun e => do
+  if let some (x, y) := e.ltOf? mkString then
+    return mkApp2 (symbolT "str.<") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.gtOf? mkString then
+    return mkApp2 (symbolT "str.>") (← applyTranslators! x) (← applyTranslators! y)
+  else
+    return none
 
 end Smt.Translate.String

--- a/Test/BitVec/Shift.expected
+++ b/Test/BitVec/Shift.expected
@@ -3,7 +3,7 @@ goal: x ++ y = zeroExtend 4 x <<< 2#2 ||| zeroExtend 4 y
 query:
 (declare-const y (_ BitVec 2))
 (declare-const x (_ BitVec 2))
-(assert (distinct (concat x y) (bvor (bvshl ((_ zero_extend 2) x) #b10) ((_ zero_extend 2) y))))
+(assert (not (= (concat x y) (bvor (bvshl ((_ zero_extend 2) x) #b10) ((_ zero_extend 2) y)))))
 (check-sat)
 Test/BitVec/Shift.lean:5:8: warning: declaration uses 'sorry'
 goal: x ++ y = zeroExtend 6 x <<< 3#2 ||| zeroExtend 6 y
@@ -11,6 +11,6 @@ goal: x ++ y = zeroExtend 6 x <<< 3#2 ||| zeroExtend 6 y
 query:
 (declare-const x (_ BitVec 3))
 (declare-const y (_ BitVec 3))
-(assert (distinct (concat x y) (bvor (bvshl ((_ zero_extend 3) x) #b11) ((_ zero_extend 3) y))))
+(assert (not (= (concat x y) (bvor (bvshl ((_ zero_extend 3) x) #b11) ((_ zero_extend 3) y)))))
 (check-sat)
 Test/BitVec/Shift.lean:10:8: warning: declaration uses 'sorry'

--- a/Test/BitVec/XorComm.expected
+++ b/Test/BitVec/XorComm.expected
@@ -3,7 +3,7 @@ goal: x ^^^ y = y ^^^ x
 query:
 (declare-const y (_ BitVec 2))
 (declare-const x (_ BitVec 2))
-(assert (distinct (bvxor x y) (bvxor y x)))
+(assert (not (= (bvxor x y) (bvxor y x))))
 (check-sat)
 Test/BitVec/XorComm.lean:3:8: warning: declaration uses 'sorry'
 goal: x ^^^ y = y ^^^ x
@@ -11,6 +11,6 @@ goal: x ^^^ y = y ^^^ x
 query:
 (declare-const y (_ BitVec 8))
 (declare-const x (_ BitVec 8))
-(assert (distinct (bvxor x y) (bvxor y x)))
+(assert (not (= (bvxor x y) (bvxor y x))))
 (check-sat)
 Test/BitVec/XorComm.lean:7:8: warning: declaration uses 'sorry'

--- a/Test/Bool/Assoc.expected
+++ b/Test/Bool/Assoc.expected
@@ -5,6 +5,6 @@ query:
 (declare-const r Bool)
 (declare-fun f (Bool Bool) Bool)
 (declare-const p Bool)
-(assert (distinct (= (f p (f q r)) (f (f p q) r)) true))
+(assert (not (= (= (f p (f q r)) (f (f p q) r)) true)))
 (check-sat)
 Test/Bool/Assoc.lean:3:8: warning: declaration uses 'sorry'

--- a/Test/Bool/Comm.expected
+++ b/Test/Bool/Comm.expected
@@ -4,6 +4,6 @@ query:
 (declare-fun f (Bool Bool) Bool)
 (declare-const q Bool)
 (declare-const p Bool)
-(assert (distinct (= (f p q) (f q p)) true))
+(assert (not (= (= (f p q) (f q p)) true)))
 (check-sat)
 Test/Bool/Comm.lean:3:0: warning: declaration uses 'sorry'

--- a/Test/Bool/Falsum.expected
+++ b/Test/Bool/Falsum.expected
@@ -1,5 +1,5 @@
 goal: (!false) = true
 
 query:
-(assert (distinct (not false) true))
+(assert (not (= (not false) true)))
 (check-sat)

--- a/Test/Bool/ModusPonens'.expected
+++ b/Test/Bool/ModusPonens'.expected
@@ -5,5 +5,5 @@ query:
 (declare-const q Bool)
 (assert (=> (= p true) (= q true)))
 (assert (= p true))
-(assert (distinct q true))
+(assert (not (= q true)))
 (check-sat)

--- a/Test/Bool/Refl.expected
+++ b/Test/Bool/Refl.expected
@@ -2,5 +2,5 @@ goal: (p == p) = true
 
 query:
 (declare-const p Bool)
-(assert (distinct (= p p) true))
+(assert (not (= (= p p) true)))
 (check-sat)

--- a/Test/Bool/Verum.expected
+++ b/Test/Bool/Verum.expected
@@ -1,5 +1,5 @@
 goal: true = true
 
 query:
-(assert (distinct true true))
+(assert (not (= true true)))
 (check-sat)

--- a/Test/Int/Binders.expected
+++ b/Test/Int/Binders.expected
@@ -4,7 +4,7 @@ query:
 (define-fun curryAdd ((a._@.Test.Int.Binders._hyg.4 Int) (a._@.Test.Int.Binders._hyg.6 Int)) Int (+ a._@.Test.Int.Binders._hyg.4 a._@.Test.Int.Binders._hyg.6))
 (declare-const a Int)
 (declare-const b Int)
-(assert (distinct (curryAdd a b) (curryAdd b a)))
+(assert (not (= (curryAdd a b) (curryAdd b a))))
 (check-sat)
 Test/Int/Binders.lean:5:0: warning: declaration uses 'sorry'
 goal: partCurryAdd a b = partCurryAdd b a
@@ -13,24 +13,24 @@ query:
 (define-fun partCurryAdd ((a Int) (a._@.Test.Int.Binders._hyg.35 Int)) Int (+ a a._@.Test.Int.Binders._hyg.35))
 (declare-const a Int)
 (declare-const b Int)
-(assert (distinct (partCurryAdd a b) (partCurryAdd b a)))
+(assert (not (= (partCurryAdd a b) (partCurryAdd b a))))
 (check-sat)
 Test/Int/Binders.lean:11:0: warning: declaration uses 'sorry'
 goal: partCurryAdd' a b = partCurryAdd' b a
 
 query:
 (define-fun |partCurryAdd'| ((a Int) (a._@.Init.Prelude._hyg.2075 Int)) Int (+ a a._@.Init.Prelude._hyg.2075))
-(declare-const b Int)
 (declare-const a Int)
-(assert (distinct (+ a b) (+ b a)))
+(declare-const b Int)
+(assert (not (= (|partCurryAdd'| a b) (|partCurryAdd'| b a))))
 (check-sat)
 Test/Int/Binders.lean:15:0: warning: declaration uses 'sorry'
 goal: mismatchNamesAdd a b = mismatchNamesAdd b a
 
 query:
 (define-fun mismatchNamesAdd ((a Int) (b Int)) Int (+ a b))
-(declare-const b Int)
 (declare-const a Int)
-(assert (distinct (mismatchNamesAdd a b) (mismatchNamesAdd b a)))
+(declare-const b Int)
+(assert (not (= (mismatchNamesAdd a b) (mismatchNamesAdd b a))))
 (check-sat)
 Test/Int/Binders.lean:25:0: warning: declaration uses 'sorry'

--- a/Test/Int/DefineSort.expected
+++ b/Test/Int/DefineSort.expected
@@ -5,6 +5,6 @@ query:
 (define-fun MyInt.add ((a MyInt) (b MyInt)) MyInt (+ a b))
 (declare-const a MyInt)
 (declare-const b MyInt)
-(assert (distinct (MyInt.add a b) (MyInt.add b a)))
+(assert (not (= (MyInt.add a b) (MyInt.add b a))))
 (check-sat)
 Test/Int/DefineSort.lean:6:0: warning: declaration uses 'sorry'

--- a/Test/Int/Dvd.expected
+++ b/Test/Int/Dvd.expected
@@ -8,7 +8,7 @@ query:
 (assert (= (dvd b c) true))
 (declare-const a Int)
 (assert (= (dvd a b) true))
-(assert (distinct (dvd a c) true))
+(assert (not (= (dvd a c) true)))
 (check-sat)
 goal: dvd c e = true
 
@@ -20,7 +20,7 @@ query:
 (assert (= (dvd d e) true))
 (declare-const c Int)
 (assert (= (dvd c d) true))
-(assert (distinct (dvd c e) true))
+(assert (not (= (dvd c e) true)))
 (check-sat)
 goal: dvd a e = true
 
@@ -32,5 +32,5 @@ query:
 (assert (= (dvd c e) true))
 (declare-const a Int)
 (assert (= (dvd a c) true))
-(assert (distinct (dvd a e) true))
+(assert (not (= (dvd a e) true)))
 (check-sat)

--- a/Test/Int/DvdTimeout.expected
+++ b/Test/Int/DvdTimeout.expected
@@ -10,7 +10,7 @@ query:
 (declare-const b Int)
 (assert (= (dvd a b) true))
 (assert (forall ((x Int)) (forall ((y Int)) (forall ((z Int)) (=> (= (dvd x y) true) (=> (= (dvd x z) true) (= (dvd x (+ y z)) true)))))))
-(assert (distinct (dvd a (+ (+ b c) d)) true))
+(assert (not (= (dvd a (+ (+ b c) d)) true)))
 (check-sat)
 Test/Int/DvdTimeout.lean:12:25: error: unsolved goals
 a b c d : Int

--- a/Test/Int/Let.expected
+++ b/Test/Int/Let.expected
@@ -4,16 +4,16 @@ query:
 (define-fun z () Int 10)
 (declare-fun f (Int) Int)
 (assert (= (f 10) 10))
-(assert (distinct (f 10) 10))
+(assert (not (= (f z) z)))
 (check-sat)
 goal: f y = y
 
 query:
 (define-fun z () Int 10)
-(define-fun y () Int 10)
+(define-fun y () Int z)
 (declare-fun f (Int) Int)
 (assert (= (f 10) 10))
-(assert (distinct (f 10) 10))
+(assert (not (= (f y) y)))
 (check-sat)
 goal: z 3 = 10
 
@@ -21,5 +21,5 @@ query:
 (declare-fun f (Int) Int)
 (define-fun z ((x._@.Test.Int.Let._hyg.292 Int)) Int (f 10))
 (assert (= (f 10) 10))
-(assert (distinct (z 3) 10))
+(assert (not (= (z 3) 10)))
 (check-sat)

--- a/Test/Nat/Cong.expected
+++ b/Test/Nat/Cong.expected
@@ -7,6 +7,6 @@ query:
 (declare-const x Nat)
 (assert (>= x 0))
 (declare-fun f (Nat) Nat)
-(assert (forall ((_uniq.1387 Nat)) (=> (>= _uniq.1387 0) (>= (f _uniq.1387) 0))))
+(assert (forall ((_uniq.28 Nat)) (=> (>= _uniq.28 0) (>= (f _uniq.28) 0))))
 (assert (not (=> (= x y) (= (f x) (f y)))))
 (check-sat)

--- a/Test/Nat/Exists''.expected
+++ b/Test/Nat/Exists''.expected
@@ -2,5 +2,5 @@ goal: ∃ x, x ≥ 0
 
 query:
 (define-sort Nat () Int)
-(assert (not (exists ((x Nat)) (<= 0 x))))
+(assert (not (exists ((x Nat)) (>= x 0))))
 (check-sat)

--- a/Test/Nat/Forall'.expected
+++ b/Test/Nat/Forall'.expected
@@ -1,5 +1,5 @@
 goal: ∀ (x : Nat), x ≥ 0
 
 query:
-(assert (not (forall ((x Int)) (=> (>= x 0) (<= 0 x)))))
+(assert (not (forall ((x Int)) (=> (>= x 0) (>= x 0)))))
 (check-sat)

--- a/Test/Nat/Max.expected
+++ b/Test/Nat/Max.expected
@@ -3,7 +3,7 @@ goal: x ≤ x.max' y ∧ y ≤ x.max' y
 query:
 (define-sort Nat () Int)
 (declare-fun |Nat.max'| (Nat Nat) Nat)
-(assert (forall ((_uniq.1383 Nat)) (=> (>= _uniq.1383 0) (forall ((_uniq.1384 Nat)) (=> (>= _uniq.1384 0) (>= (|Nat.max'| _uniq.1383 _uniq.1384) 0))))))
+(assert (forall ((_uniq.83 Nat)) (=> (>= _uniq.83 0) (forall ((_uniq.84 Nat)) (=> (>= _uniq.84 0) (>= (|Nat.max'| _uniq.83 _uniq.84) 0))))))
 (declare-const y Nat)
 (assert (>= y 0))
 (declare-const x Nat)
@@ -15,7 +15,7 @@ goal: x ≤ x.max' y ∧ y ≤ x.max' y
 query:
 (define-sort Nat () Int)
 (define-fun |Nat.max'| ((x Nat) (y Nat)) Nat (ite (<= x y) y x))
-(assert (forall ((_uniq.1519 Nat)) (=> (>= _uniq.1519 0) (forall ((_uniq.1520 Nat)) (=> (>= _uniq.1520 0) (>= (|Nat.max'| _uniq.1519 _uniq.1520) 0))))))
+(assert (forall ((_uniq.100 Nat)) (=> (>= _uniq.100 0) (forall ((_uniq.101 Nat)) (=> (>= _uniq.101 0) (>= (|Nat.max'| _uniq.100 _uniq.101) 0))))))
 (declare-const y Nat)
 (assert (>= y 0))
 (declare-const x Nat)

--- a/Test/Nat/Triv'.expected
+++ b/Test/Nat/Triv'.expected
@@ -1,5 +1,5 @@
 goal: 0 + 1 = 1
 
 query:
-(assert (distinct (+ 0 1) 1))
+(assert (not (= (+ 0 1) 1)))
 (check-sat)

--- a/Test/Nat/Triv.expected
+++ b/Test/Nat/Triv.expected
@@ -1,5 +1,5 @@
 goal: Nat.zero + Nat.zero.succ = Nat.zero.succ
 
 query:
-(assert (distinct (+ 0 1) (+ 0 1)))
+(assert (not (= (+ 0 (+ 0 1)) (+ 0 1))))
 (check-sat)

--- a/Test/Nat/ZeroSub'.expected
+++ b/Test/Nat/ZeroSub'.expected
@@ -1,6 +1,6 @@
 Test/Nat/ZeroSub'.lean:6:12: error: tactic 'assumption' failed
 case zero
-_uniq✝⁷⁶⁸⁻⁰ : ¬0 ≠ 0
+_uniq✝²⁸³⁻⁰ : ¬¬(if 0 ≤ 0 then 0 - 0 else 0) = 0
 ⊢ ¬andN ([] ++ [¬0 - 0 = 0])
 Test/Nat/ZeroSub'.lean:7:17: error: application type mismatch
   HAdd.hAdd x

--- a/Test/Nat/ZeroSub.expected
+++ b/Test/Nat/ZeroSub.expected
@@ -4,5 +4,5 @@ query:
 (define-sort Nat () Int)
 (declare-const x Nat)
 (assert (>= x 0))
-(assert (distinct (ite (<= x 0) (- 0 x) 0) 0))
+(assert (not (= (ite (<= x 0) (- 0 x) 0) 0)))
 (check-sat)

--- a/Test/Rat/linarith.expected
+++ b/Test/Rat/linarith.expected
@@ -1,8 +1,8 @@
-Test/Rat/linarith.lean:74:9: warning: unused variable `a`
+Test/Rat/linarith.lean:106:9: warning: unused variable `a`
 note: this linter can be disabled with `set_option linter.unusedVariables false`
-Test/Rat/linarith.lean:74:13: warning: unused variable `c`
+Test/Rat/linarith.lean:106:13: warning: unused variable `c`
 note: this linter can be disabled with `set_option linter.unusedVariables false`
-Test/Rat/linarith.lean:84:9: warning: unused variable `a`
+Test/Rat/linarith.lean:116:9: warning: unused variable `a`
 note: this linter can be disabled with `set_option linter.unusedVariables false`
-Test/Rat/linarith.lean:84:13: warning: unused variable `c`
+Test/Rat/linarith.lean:116:13: warning: unused variable `c`
 note: this linter can be disabled with `set_option linter.unusedVariables false`

--- a/Test/Rat/linarith.lean
+++ b/Test/Rat/linarith.lean
@@ -1,30 +1,62 @@
 import Smt
 import Smt.Rat
 
+def Lean.Expr.ratAbs? (e : Lean.Expr) : Option Expr := do
+  let .app (.const ``Rat.abs _) x := e | none
+  return x
+
+def Lean.Expr.ratFloor? (e : Lean.Expr) : Option Expr := do
+  let .app (.const ``Rat.floor _) x := e | none
+  return x
+
 namespace Smt.Translate.Rat
 
-open Qq
 open Translator Term
 
-@[smt_translate] def translateType : Translator := fun (e : Q(Type)) => match e with
-  | ~q(Rat) => return symbolT "Real"
-  | _       => return none
+private def mkRat : Lean.Expr :=
+  .const ``Rat []
 
-@[smt_translate] def translateRat : Translator := fun (e : Q(Rat)) => match e with
-  | ~q(OfNat.ofNat $n) => return if let some n := n.rawNatLit? then literalT s!"{n}.0" else none
-  | ~q(-$x)     => return appT (symbolT "-") (← applyTranslators! x)
-  | ~q($x + $y) => return mkApp2 (symbolT "+") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x - $y) => return mkApp2 (symbolT "-") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x * $y) => return mkApp2 (symbolT "*") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q($x / $y) => return mkApp2 (symbolT "/") (← applyTranslators! x) (← applyTranslators! y)
-  | _           => return none
+@[smt_translate] def translateType : Translator := fun e => match e with
+  | .const ``Rat _  => return symbolT "Real"
+  | _                => return none
 
-@[smt_translate] def translateProp : Translator := fun (e : Q(Prop)) => match e with
-  | ~q(($x : Rat) < $y) => return mkApp2 (symbolT "<") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : Rat) ≤ $y) => return mkApp2 (symbolT "<=") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : Rat) ≥ $y) => return mkApp2 (symbolT ">=") (← applyTranslators! x) (← applyTranslators! y)
-  | ~q(($x : Rat) > $y) => return mkApp2 (symbolT ">") (← applyTranslators! x) (← applyTranslators! y)
-  | _                   => return none
+@[smt_translate] def translateInt : Translator := fun e => do
+  if let some x := e.ratFloor? then
+    return appT (symbolT "to_int") (← applyTranslators! x)
+  else
+    return none
+
+@[smt_translate] def translateRat : Translator := fun e => do
+  if let some n := e.natLitOf? mkRat then
+    return literalT s!"{n}.0"
+  else if let some x := e.intCastOf? mkRat then
+    return appT (symbolT "to_real") (← applyTranslators! x)
+  else if let some x := e.negOf? mkRat then
+    return appT (symbolT "-") (← applyTranslators! x)
+  else if let some x := e.ratAbs? then
+    return appT (symbolT "abs") (← applyTranslators! x)
+  else if let some (x, y) := e.hAddOf? mkRat mkRat then
+    return mkApp2 (symbolT "+") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.hSubOf? mkRat mkRat then
+    return mkApp2 (symbolT "-") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.hMulOf? mkRat mkRat then
+    return mkApp2 (symbolT "*") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.hDivOf? mkRat mkRat then
+    return mkApp2 (symbolT "/") (← applyTranslators! x) (← applyTranslators! y)
+  else
+    return none
+
+@[smt_translate] def translateProp : Translator := fun e => do
+  if let some (x, y) := e.ltOf? mkRat then
+    return mkApp2 (symbolT "<") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.leOf? mkRat then
+    return mkApp2 (symbolT "<=") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.geOf? mkRat then
+    return mkApp2 (symbolT ">=") (← applyTranslators! x) (← applyTranslators! y)
+  else if let some (x, y) := e.gtOf? mkRat then
+    return mkApp2 (symbolT ">") (← applyTranslators! x) (← applyTranslators! y)
+  else
+    return none
 
 end Smt.Translate.Rat
 

--- a/Test/String/Append.expected
+++ b/Test/String/Append.expected
@@ -1,5 +1,5 @@
 goal: "a" ++ "b" = "ab"
 
 query:
-(assert (distinct (str.++ "a" "b") "ab"))
+(assert (not (= (str.++ "a" "b") "ab")))
 (check-sat)

--- a/Test/String/Contains.expected
+++ b/Test/String/Contains.expected
@@ -1,10 +1,1 @@
-goal: "a".contains 'a' = true
-
-query:
-(declare-sort Char 0)
-(declare-fun String.contains (String Char) Bool)
-(define-sort Nat () Int)
-(declare-fun Char.ofNat (Nat) Char)
-(assert (distinct (String.contains "a" (Char.ofNat (+ 96 1))) true))
-(check-sat)
-Test/String/Contains.lean:3:8: warning: declaration uses 'sorry'
+Test/String/Contains.lean:4:2: error: cannot translate 97

--- a/Test/String/Empty.expected
+++ b/Test/String/Empty.expected
@@ -1,5 +1,5 @@
 goal: "" = ""
 
 query:
-(assert (distinct "" ""))
+(assert (not (= "" "")))
 (check-sat)

--- a/Test/String/GetOp.expected
+++ b/Test/String/GetOp.expected
@@ -1,1 +1,1 @@
-Test/String/GetOp.lean:4:2: error: incorrect number of universe levels OfNat
+Test/String/GetOp.lean:4:2: error: cannot translate 0

--- a/Test/String/Length.expected
+++ b/Test/String/Length.expected
@@ -1,8 +1,5 @@
 goal: "a".length = 1
 
 query:
-(define-sort Nat () Int)
-(declare-fun String.length (String) Nat)
-(assert (forall ((_uniq.937 String)) (>= (String.length _uniq.937) 0)))
-(assert (distinct (String.length "a") 1))
+(assert (not (= (str.len "a") 1)))
 (check-sat)

--- a/Test/String/Replace.expected
+++ b/Test/String/Replace.expected
@@ -1,6 +1,6 @@
 goal: "a".replace "a" "b" = "b"
 
 query:
-(assert (distinct (str.replace_all "a" "a" "b") "b"))
+(assert (not (= (str.replace_all "a" "a" "b") "b")))
 (check-sat)
 Test/String/Replace.lean:3:8: warning: declaration uses 'sorry'


### PR DESCRIPTION
The usage of quote4 for pattern-matching caused significant performance overhead (up to 100x) due to its usage of definitional equality for matching instead of structural equality. I opened an [issue](https://github.com/leanprover-community/quote4/issues/82) requesting an option to use structural equality. In the meantime, this PR eliminates the use of quote4 for pattern-matching. As a side-effect, the translation into SMT-LIB is now more faithful. However, it is more likely to fail as well.

Closes #126.