### PR TITLE
Fallback to real reconstruction if one of the arguments is real

### DIFF
--- a/Smt/Reconstruct/Int.lean
+++ b/Smt/Reconstruct/Int.lean
@@ -63,22 +63,22 @@ open Qq
     let x : Q(Int) ← reconstructTerm t[0]!
     return q(«$x».abs)
   | .LEQ =>
-    if !t[0]!.getSort.isInteger then return none
+    if !t[0]!.getSort.isInteger || !t[1]!.getSort.isInteger then return none
     let x : Q(Int) ← reconstructTerm t[0]!
     let y : Q(Int) ← reconstructTerm t[1]!
     return q($x ≤ $y)
   | .LT =>
-    if !t[0]!.getSort.isInteger then return none
+    if !t[0]!.getSort.isInteger || !t[1]!.getSort.isInteger then return none
     let x : Q(Int) ← reconstructTerm t[0]!
     let y : Q(Int) ← reconstructTerm t[1]!
     return q($x < $y)
   | .GEQ =>
-    if !t[0]!.getSort.isInteger then return none
+    if !t[0]!.getSort.isInteger || !t[1]!.getSort.isInteger then return none
     let x : Q(Int) ← reconstructTerm t[0]!
     let y : Q(Int) ← reconstructTerm t[1]!
     return q($x ≥ $y)
   | .GT =>
-    if !t[0]!.getSort.isInteger then return none
+    if !t[0]!.getSort.isInteger || !t[1]!.getSort.isInteger then return none
     let x : Q(Int) ← reconstructTerm t[0]!
     let y : Q(Int) ← reconstructTerm t[1]!
     return q($x > $y)

--- a/Smt/Reconstruct/Real.lean
+++ b/Smt/Reconstruct/Real.lean
@@ -59,24 +59,64 @@ open Lean Qq
     let x : Q(Real) ← reconstructTerm t[0]!
     return q(|$x|)
   | .LEQ =>
-    if t[0]!.getSort.isInteger then return none
-    let x : Q(Real) ← reconstructTerm t[0]!
-    let y : Q(Real) ← reconstructTerm t[1]!
+    if t[0]!.getSort.isInteger && t[1]!.getSort.isInteger then return none
+    let x ← reconstructTerm t[0]!
+    let x : Q(Real) :=
+      if (← Meta.inferType x) == .const `Int [] then
+        let x : Q(Int) := x
+        q(IntCast.intCast (R := Real) $x)
+      else x
+    let y ← reconstructTerm t[1]!
+    let y : Q(Real) :=
+      if (← Meta.inferType y) == .const `Int [] then
+        let y : Q(Int) := y
+        q(IntCast.intCast (R := Real) $y)
+      else y
     return q($x ≤ $y)
   | .LT =>
-    if t[0]!.getSort.isInteger then return none
-    let x : Q(Real) ← reconstructTerm t[0]!
-    let y : Q(Real) ← reconstructTerm t[1]!
+    if t[0]!.getSort.isInteger && t[1]!.getSort.isInteger then return none
+    let x ← reconstructTerm t[0]!
+    let x : Q(Real) :=
+      if (← Meta.inferType x) == .const `Int [] then
+        let x : Q(Int) := x
+        q(IntCast.intCast (R := Real) $x)
+      else x
+    let y ← reconstructTerm t[1]!
+    let y : Q(Real) :=
+      if (← Meta.inferType y) == .const `Int [] then
+        let y : Q(Int) := y
+        q(IntCast.intCast (R := Real) $y)
+      else y
     return q($x < $y)
   | .GEQ =>
-    if t[0]!.getSort.isInteger then return none
-    let x : Q(Real) ← reconstructTerm t[0]!
-    let y : Q(Real) ← reconstructTerm t[1]!
+    if t[0]!.getSort.isInteger && t[1]!.getSort.isInteger then return none
+    let x ← reconstructTerm t[0]!
+    let x : Q(Real) :=
+      if (← Meta.inferType x) == .const `Int [] then
+        let x : Q(Int) := x
+        q(IntCast.intCast (R := Real) $x)
+      else x
+    let y ← reconstructTerm t[1]!
+    let y : Q(Real) :=
+      if (← Meta.inferType y) == .const `Int [] then
+        let y : Q(Int) := y
+        q(IntCast.intCast (R := Real) $y)
+      else y
     return q($x ≥ $y)
   | .GT =>
-    if t[0]!.getSort.isInteger then return none
-    let x : Q(Real) ← reconstructTerm t[0]!
-    let y : Q(Real) ← reconstructTerm t[1]!
+    if t[0]!.getSort.isInteger && t[1]!.getSort.isInteger then return none
+    let x ← reconstructTerm t[0]!
+    let x : Q(Real) :=
+      if (← Meta.inferType x) == .const `Int [] then
+        let x : Q(Int) := x
+        q(IntCast.intCast (R := Real) $x)
+      else x
+    let y ← reconstructTerm t[1]!
+    let y : Q(Real) :=
+      if (← Meta.inferType y) == .const `Int [] then
+        let y : Q(Int) := y
+        q(IntCast.intCast (R := Real) $y)
+      else y
     return q($x > $y)
   | .TO_REAL =>
     let x : Q(Int) ← reconstructTerm t[0]!


### PR DESCRIPTION
Got this bug today: if one of the arguments for LEQ (or LT, GEQ, GT) is real and the other an integer, then we should use the real reconstructor (with the appropriate cast) and not the integer one, otherwise we get a typing error.