### PR TITLE
Fix timeouts and add ability for passing custom solver options

### DIFF
--- a/Smt/Reconstruct.lean
+++ b/Smt/Reconstruct.lean
@@ -247,21 +247,26 @@ def traceSolve (r : Except Exception (Except Error cvc5Result)) : MetaM MessageD
   | .ok (.ok _) => m!"{checkEmoji}"
   | _           => m!"{bombEmoji}"
 
+def defaultSolverOptions : List (String × String) := [
+  ("dag-thresh", "0"),
+  ("simplification", "none"),
+  ("enum-inst", "true"),
+  ("enum-inst-interleave", "true"),
+  ("cegqi-midpoint", "true"),
+  ("produce-models", "true"),
+  ("produce-proofs", "true"),
+  ("proof-elim-subtypes", "true"),
+  ("proof-granularity", "dsl-rewrite"),
+]
+
 open cvc5 in
-def solve (query : String) (timeout : Option Nat) : MetaM (Except cvc5.Error cvc5Result) :=
+def solve (query : String) (timeout : Option Nat) (options : List (String × String)) : MetaM (Except cvc5.Error cvc5Result) :=
   profileitM Exception "smt" {} do
   withTraceNode `smt.solve traceSolve do Solver.run (← TermManager.new) do
     if let .some timeout := timeout then
       Solver.setOption "tlimit" (toString (1000*timeout))
-    Solver.setOption "dag-thresh" "0"
-    Solver.setOption "simplification" "none"
-    Solver.setOption "enum-inst" "true"
-    Solver.setOption "enum-inst-interleave" "true"
-    Solver.setOption "cegqi-midpoint" "true"
-    Solver.setOption "produce-models" "true"
-    Solver.setOption "produce-proofs" "true"
-    Solver.setOption "proof-elim-subtypes" "true"
-    Solver.setOption "proof-granularity" "dsl-rewrite"
+    for (opt, val) in options do
+      Solver.setOption opt val
     let (uss, ufs) ← Solver.parseCommands query
     let res ← Solver.checkSat
     trace[smt.solve] m!"result: {res}"
@@ -289,7 +294,7 @@ open Lean.Elab Tactic in
 @[tactic reconstruct] def evalReconstruct : Tactic := fun stx =>
   withMainContext do
     let some query := stx[1].isStrLit? | throwError "expected string"
-    let r ← solve query none
+    let r ← solve query none defaultSolverOptions
     match r with
       | .error e => throwError e.toString
       | .ok (.sat _) => throwError "expected unsat result"

--- a/Smt/Reconstruct.lean
+++ b/Smt/Reconstruct.lean
@@ -264,7 +264,10 @@ def solve (query : String) (timeout : Option Nat) (options : List (String × Str
   profileitM Exception "smt" {} do
   withTraceNode `smt.solve traceSolve do Solver.run (← TermManager.new) do
     if let .some timeout := timeout then
-      Solver.setOption "tlimit" (toString (1000*timeout))
+      -- NOTE: `tlimit` wouldn't have any effect here, since we're not running in
+      -- the binary, and because we only have a single `checkSat`, we can use
+      -- `tlimit-per` instead to achieve the same effect.
+      Solver.setOption "tlimit-per" (toString (1000*timeout))
     for (opt, val) in options do
       Solver.setOption opt val
     let (uss, ufs) ← Solver.parseCommands query

--- a/Smt/Tactic/Smt.lean
+++ b/Smt/Tactic/Smt.lean
@@ -41,6 +41,8 @@ structure Config where
   model : Bool := false
   /-- Just show the SMT query without invoking a solver. Useful for debugging. -/
   showQuery : Bool := false
+  /-- Options to pass to the solver, in addition to the default ones. -/
+  extraSolverOptions : List (String × String) := []
 deriving Inhabited, Repr
 
 inductive Result where
@@ -83,7 +85,7 @@ def smt (cfg : Config) (mv : MVarId) (hs : Array Expr) : MetaM Result := mv.with
     trace[smt] "goal: {goalType}"
     trace[smt] "\nquery:\n{Command.cmdsAsQuery (cmds ++ [.checkSat])}"
   -- 4. Run the solver.
-  let res ← solve (Command.cmdsAsQuery cmds) cfg.timeout
+  let res ← solve (Command.cmdsAsQuery cmds) cfg.timeout (defaultSolverOptions ++ cfg.extraSolverOptions)
   -- trace[smt] "\nresult: {res}"
   match res with
   | .error e =>

--- a/Smt/Translate/Solver.lean
+++ b/Smt/Translate/Solver.lean
@@ -47,16 +47,6 @@ def Kind.toDefaultPath : Kind → String
   | .yices => "yices-smt2"
   | k      => toString k
 
-register_option smt.solver.kind : Kind := {
-  defValue := Kind.cvc5
-  descr := "The solver to use for solving the SMT query."
-}
-
-register_option smt.solver.path : String := {
-  defValue := "cvc5"
-  descr := "The path to the solver used for solving the SMT query."
-}
-
 /-- Result of an SMT query. -/
 inductive Result where
   | sat     : Result

--- a/Test/Int/Binders.expected
+++ b/Test/Int/Binders.expected
@@ -12,7 +12,7 @@ goal: partCurryAdd a b = partCurryAdd b a
 
 query:
 (set-logic ALL)
-(define-fun partCurryAdd ((a Int) (a._@.Test.Int.Binders._hyg.58 Int)) Int (+ a a._@.Test.Int.Binders._hyg.58))
+(define-fun partCurryAdd ((a Int) (a._@.Test.Int.Binders._hyg.60 Int)) Int (+ a a._@.Test.Int.Binders._hyg.60))
 (declare-const b Int)
 (declare-const a Int)
 (assert (not (= (partCurryAdd a b) (partCurryAdd b a))))

--- a/Test/Int/Let.expected
+++ b/Test/Int/Let.expected
@@ -22,7 +22,7 @@ goal: z 3 = 10
 query:
 (set-logic ALL)
 (declare-fun f (Int) Int)
-(define-fun z ((x._@.Test.Int.Let._hyg.330 Int)) Int (f 10))
+(define-fun z ((x._@.Test.Int.Let._hyg.334 Int)) Int (f 10))
 (assert (= (f 10) 10))
 (assert (not (= (z 3) 10)))
 (check-sat)

--- a/Test/Nat/Cong.expected
+++ b/Test/Nat/Cong.expected
@@ -8,6 +8,6 @@ query:
 (declare-const x Nat)
 (assert (>= x 0))
 (declare-fun f (Nat) Nat)
-(assert (forall ((_uniq.63 Nat)) (=> (>= _uniq.63 0) (>= (f _uniq.63) 0))))
+(assert (forall ((_uniq.80 Nat)) (=> (>= _uniq.80 0) (>= (f _uniq.80) 0))))
 (assert (not (=> (= x y) (= (f x) (f y)))))
 (check-sat)

--- a/Test/Nat/Max.expected
+++ b/Test/Nat/Max.expected
@@ -6,7 +6,7 @@ query:
 (declare-const y Nat)
 (assert (>= y 0))
 (declare-fun |Nat.max'| (Nat Nat) Nat)
-(assert (forall ((_uniq.122 Nat)) (=> (>= _uniq.122 0) (forall ((_uniq.123 Nat)) (=> (>= _uniq.123 0) (>= (|Nat.max'| _uniq.122 _uniq.123) 0))))))
+(assert (forall ((_uniq.139 Nat)) (=> (>= _uniq.139 0) (forall ((_uniq.140 Nat)) (=> (>= _uniq.140 0) (>= (|Nat.max'| _uniq.139 _uniq.140) 0))))))
 (declare-const x Nat)
 (assert (>= x 0))
 (assert (not (and (<= x (|Nat.max'| x y)) (<= y (|Nat.max'| x y)))))


### PR DESCRIPTION
This fixes some of the annoyances we encountered with solver options in `lean-smt`.