### PR TITLE
fix: eliminate sorry in Bitblast and resolve String.next warning

### DIFF
--- a/Smt/Data/Sexp.lean
+++ b/Smt/Data/Sexp.lean
@@ -86,9 +86,9 @@ always succeed.
 def manySexps : Parser (List Sexp) := do
   let mut stack : List (List Sexp) := []
   let mut curr := []
-  let mut next ← misc *> peek?
-  while h : next.isSome do
-    match next.get h with
+  let mut nextChar ← misc *> peek?
+  while h : nextChar.isSome do
+    match nextChar.get h with
     | '(' =>
       skipChar '('
       stack := curr :: stack
@@ -103,7 +103,7 @@ def manySexps : Parser (List Sexp) := do
         curr := .expr curr.reverse :: sexp
     | _ =>
       curr := (← atom) :: curr
-    next ← misc *> peek?
+    nextChar ← misc *> peek?
   if !stack.isEmpty then
     fail "expected ')'"
   return curr.reverse

--- a/Smt/Reconstruct/BitVec/Bitblast.lean
+++ b/Smt/Reconstruct/BitVec/Bitblast.lean
@@ -33,8 +33,54 @@ where
     | 0     => x.getLsbD (w - 1) == y.getLsbD (w - 1)
     | i + 1 => x.getLsbD ((w - 1) - (i + 1)) == y.getLsbD ((w - 1) - (i + 1)) && go i
 
-def eq_eq_beq (x : BitVec w) (y : BitVec w) : (x = y) = x.beq y :=
-  sorry
+theorem beq_go_imp_eq {w : Nat} (x y : BitVec w) (i : Nat) :
+    beq.go x y i = true → ∀ j, w - 1 - i ≤ j → j < w → x.getLsbD j = y.getLsbD j := by
+  induction i with
+  | zero =>
+    intro h j h1 _
+    have hj : j = w - 1 := by omega
+    subst hj
+    revert h
+    unfold beq.go
+    intro h
+    exact eq_of_beq h
+  | succ i ih =>
+    intro h j h1 h2
+    revert h
+    unfold beq.go
+    intro h
+    have h_and := (Bool.and_eq_true _ _).mp h
+    have hj_cases : j = w - 1 - (i + 1) ∨ w - 1 - i ≤ j := by omega
+    cases hj_cases with
+    | inl hj_eq =>
+      subst hj_eq
+      exact eq_of_beq h_and.1
+    | inr hj_gt =>
+      exact ih h_and.2 j hj_gt h2
+
+theorem beq_go_self {w : Nat} (x : BitVec w) (i : Nat) : beq.go x x i = true := by
+  induction i with
+  | zero =>
+    unfold beq.go
+    simp
+  | succ i ih =>
+    unfold beq.go
+    simp [ih]
+
+def eq_eq_beq (x : BitVec w) (y : BitVec w) : (x = y) = x.beq y := by
+  apply propext
+  constructor
+  · intro h
+    subst h
+    unfold beq
+    exact beq_go_self x (w - 1)
+  · intro h
+    apply BitVec.eq_of_getLsbD_eq
+    intro j hj
+    unfold beq at h
+    apply beq_go_imp_eq x y (w - 1) h j
+    · omega
+    · exact hj
 
 /-- Carry function for bitwise addition. -/
 def adcb' (x y c : Bool) : Bool × Bool := (x && y || Bool.xor x y && c, (Bool.xor (Bool.xor x y) c))


### PR DESCRIPTION
This PR fixes two issues for Lean v4.29.0 compatibility:

1. **Eliminated `sorry` in `Smt/Reconstruct/BitVec/Bitblast.lean`:** Proved `eq_eq_beq` via induction on `beq.go`. Used `omega` for index arithmetic and replaced the deprecated `ext` alias with `BitVec.eq_of_getLsbD_eq`.

2. **Fixed deprecation warning in `Smt/Data/Sexp.lean`:** Renamed the local variable `next` to `nextChar` in `manySexps` to prevent shadowing the globally opened `String.next`.

