### PR TITLE
`Fin` embeddings in preprocessing

### DIFF
--- a/Smt.lean
+++ b/Smt.lean
@@ -9,6 +9,7 @@ import Smt.BitVec
 import Smt.Bool
 import Smt.Builtin
 import Smt.Datatype
+import Smt.Fin
 import Smt.Int
 import Smt.Nat
 import Smt.Options

--- a/Smt/Fin.lean
+++ b/Smt/Fin.lean
@@ -1,0 +1,8 @@
+/-
+Copyright (c) 2021-2026 by the authors listed in the file AUTHORS and their
+institutional affiliations. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: George Pîrlea
+-/
+
+import Smt.Preprocess.Embedding.Fin

--- a/Smt/Preprocess/Embedding.lean
+++ b/Smt/Preprocess/Embedding.lean
@@ -16,6 +16,22 @@ namespace Smt.Preprocess
 
 open Lean
 
+private def isFinType (e : Expr) : Bool :=
+  match e.consumeMData with
+  | .app (.const ``Fin []) _ => true
+  | _                        => false
+
+private def isEmbeddingType (includeRat : Bool) (e : Expr) : Bool :=
+  e.consumeMData.isConstOf ``Nat ||
+  e.consumeMData.isConstOf ``Bool ||
+  (includeRat && e.consumeMData.isConstOf ``Rat) ||
+  isFinType e
+
+private def isEmbeddingAssumptionType (includeRat : Bool) (e : Expr) : Bool :=
+  e.consumeMData.isConstOf ``Nat ||
+  (includeRat && e.consumeMData.isConstOf ``Rat) ||
+  isFinType e
+
 def hasType (e : Expr) (p : Expr → Bool) : Bool :=
   match e with
   | .forallE _ t b _ => p t || hasType b p
@@ -32,9 +48,9 @@ def embedding (mv : MVarId) (hs : Array Expr) : MetaM Result := mv.withContext d
   let ⟨_, _, fvs⟩ := (ts.push (← mv.getType)).foldl Lean.collectFVars {}
   let fvs ← Meta.sortFVarIds fvs
   -- Check if we need to do anything.
-  let bts := if (← getEnv).contains `Real then  #[``Nat, ``Rat, ``Bool] else #[``Nat, ``Bool]
+  let includeRat := (← getEnv).contains `Real
   let fvts ← fvs.mapM FVarId.getType
-  if !(fvts ++ ts.push (← mv.getType)).any (·.contains ((bts.map (.const · [])).contains ·)) then
+  if !(fvts ++ ts.push (← mv.getType)).any (·.contains (isEmbeddingType includeRat)) then
     return ⟨{}, hs, mv⟩
   -- Find the embedding simp theorems.
   let some thmsExt ← Meta.getSimpExtension? `embedding | throwError "embedding simp extension not found"
@@ -59,12 +75,11 @@ def embedding (mv : MVarId) (hs : Array Expr) : MetaM Result := mv.withContext d
   let ctx ← Meta.Simp.mkContext { zeta := false, singlePass := true } simpTheorems congrTheorems
   let (some mv, _) ← Meta.simpTarget mv ctx simpProcs (mayCloseGoal := false) | throwError "[embedding] simplification failed"
   -- Extend `fvs` to account for `nonneg` assumptions.
-  let bts := bts.pop -- Do not consider `Bool` for assumptions.
   let mut fvs' : Array (Option FVarId) := #[]
   for fv in fvs do
     fvs' := fvs'.push (some fv)
     let t ← fv.getType
-    if hasReturnType t ((bts.map (.const · [])).contains ·) then
+    if hasReturnType t (isEmbeddingAssumptionType includeRat) then
       fvs' := fvs'.push none
   -- Re-introduce all free vars (and their `nonneg` assumptions).
   let (fvs'', mv) ← mv.introNP fvs'.size

--- a/Smt/Preprocess/Embedding/Fin.lean
+++ b/Smt/Preprocess/Embedding/Fin.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2021-2026 by the authors listed in the file AUTHORS and their
+institutional affiliations. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: George Pîrlea
+-/
+
+import Smt.Preprocess.Embedding.Attribute
+
+attribute [embedding ↓] Fin.ext_iff
+attribute [embedding ↓] Fin.val_zero
+attribute [embedding ↓] Fin.val_one
+attribute [embedding ↓] Fin.val_ofNat
+attribute [embedding ↓] Fin.mk.injEq
+
+namespace Smt.Preprocess.Embedding
+
+def ofIntFin (n : Nat) (x : Int) (h : 0 ≤ x ∧ x < n) : Fin n :=
+  ⟨x.toNat, (Int.toNat_lt h.1).2 h.2⟩
+
+@[embedding ↓]
+theorem Int.natCast_ofIntFin {n : Nat} {x : Int} {h : 0 ≤ x ∧ x < n} :
+    (((ofIntFin n x h : Fin n) : Nat) : Int) = x :=
+  Int.toNat_of_nonneg h.1
+
+theorem ofIntFin_of_fin {n : Nat} (x : Fin n)
+    (h : 0 ≤ ((x : Nat) : Int) ∧ ((x : Nat) : Int) < n) :
+    ofIntFin n ((x : Nat) : Int) h = x := by
+  apply Fin.ext
+  simp [ofIntFin]
+
+def ofIntFinTotal (n : Nat) [NeZero n] (x : Int) : Fin n :=
+  Fin.ofNat n x.toNat
+
+theorem ofIntFinTotal_of_fin {n : Nat} [NeZero n] (x : Fin n) :
+    ofIntFinTotal n ((x : Nat) : Int) = x := by
+  apply Fin.ext
+  simp [ofIntFinTotal]
+
+@[embedding ↓]
+theorem forall_fin_as_int {n : Nat} {p : Fin n → Prop} :
+    (∀ x : Fin n, p x) ↔
+    (∀ x : Int, (h : 0 ≤ x ∧ x < n) → p (ofIntFin n x h)) := by
+  constructor
+  · intro h x hx
+    exact h (ofIntFin n x hx)
+  · intro h x
+    have hx := h ((x : Nat) : Int) (by
+      constructor
+      · exact Int.natCast_nonneg x.val
+      · exact_mod_cast x.isLt)
+    simpa [ofIntFin_of_fin] using hx
+
+@[embedding ↓]
+theorem exists_fin_as_int {n : Nat} {p : Fin n → Prop} :
+    (∃ x : Fin n, p x) ↔
+    (∃ x : Int, ∃ h : 0 ≤ x ∧ x < n, p (ofIntFin n x h)) := by
+  constructor
+  · intro ⟨x, hx⟩
+    refine ⟨(x : Nat), ?_, ?_⟩
+    · constructor
+      · exact Int.natCast_nonneg x.val
+      · exact_mod_cast x.isLt
+    · simpa [ofIntFin_of_fin] using hx
+  · intro ⟨x, hx, hp⟩
+    exact ⟨ofIntFin n x hx, hp⟩
+
+@[embedding ↓]
+theorem forall_fin_out_as_int₁ {n : Nat} {p : (α₁ → Fin n) → Prop} :
+    (∀ f : α₁ → Fin n, p f) ↔
+    (∀ f : α₁ → Int, (hf : ∀ a₁, 0 ≤ f a₁ ∧ f a₁ < n) →
+      p (fun a₁ => ofIntFin n (f a₁) (hf a₁))) := by
+  constructor
+  · intro h f hf
+    exact h (fun a₁ => ofIntFin n (f a₁) (hf a₁))
+  · intro h f
+    have hf := h (fun a₁ => ((f a₁ : Nat) : Int)) (fun a₁ => by
+      constructor
+      · exact Int.natCast_nonneg (f a₁).val
+      · exact Int.ofNat_lt.mpr (f a₁).isLt)
+    simpa [ofIntFin_of_fin] using hf
+
+@[embedding ↓]
+theorem forall_fin_out_as_int₂ {n : Nat} {p : (α₁ → α₂ → Fin n) → Prop} :
+    (∀ f : α₁ → α₂ → Fin n, p f) ↔
+    (∀ f : α₁ → α₂ → Int, (hf : ∀ a₁ a₂, 0 ≤ f a₁ a₂ ∧ f a₁ a₂ < n) →
+      p (fun a₁ a₂ => ofIntFin n (f a₁ a₂) (hf a₁ a₂))) := by
+  constructor
+  · intro h f hf
+    exact h (fun a₁ a₂ => ofIntFin n (f a₁ a₂) (hf a₁ a₂))
+  · intro h f
+    have hf := h (fun a₁ a₂ => ((f a₁ a₂ : Nat) : Int)) (fun a₁ a₂ => by
+      constructor
+      · exact Int.natCast_nonneg (f a₁ a₂).val
+      · exact Int.ofNat_lt.mpr (f a₁ a₂).isLt)
+    simpa [ofIntFin_of_fin] using hf
+
+@[embedding ↓]
+theorem forall_fin_out_as_int₃ {n : Nat} {p : (α₁ → α₂ → α₃ → Fin n) → Prop} :
+    (∀ f : α₁ → α₂ → α₃ → Fin n, p f) ↔
+    (∀ f : α₁ → α₂ → α₃ → Int,
+      (hf : ∀ a₁ a₂ a₃, 0 ≤ f a₁ a₂ a₃ ∧ f a₁ a₂ a₃ < n) →
+      p (fun a₁ a₂ a₃ => ofIntFin n (f a₁ a₂ a₃) (hf a₁ a₂ a₃))) := by
+  constructor
+  · intro h f hf
+    exact h (fun a₁ a₂ a₃ => ofIntFin n (f a₁ a₂ a₃) (hf a₁ a₂ a₃))
+  · intro h f
+    have hf := h (fun a₁ a₂ a₃ => ((f a₁ a₂ a₃ : Nat) : Int)) (fun a₁ a₂ a₃ => by
+      constructor
+      · exact Int.natCast_nonneg (f a₁ a₂ a₃).val
+      · exact Int.ofNat_lt.mpr (f a₁ a₂ a₃).isLt)
+    simpa [ofIntFin_of_fin] using hf
+
+@[embedding ↓]
+theorem forall_fin_out_as_int₄ {n : Nat} {p : (α₁ → α₂ → α₃ → α₄ → Fin n) → Prop} :
+    (∀ f : α₁ → α₂ → α₃ → α₄ → Fin n, p f) ↔
+    (∀ f : α₁ → α₂ → α₃ → α₄ → Int,
+      (hf : ∀ a₁ a₂ a₃ a₄, 0 ≤ f a₁ a₂ a₃ a₄ ∧ f a₁ a₂ a₃ a₄ < n) →
+      p (fun a₁ a₂ a₃ a₄ => ofIntFin n (f a₁ a₂ a₃ a₄) (hf a₁ a₂ a₃ a₄))) := by
+  constructor
+  · intro h f hf
+    exact h (fun a₁ a₂ a₃ a₄ => ofIntFin n (f a₁ a₂ a₃ a₄) (hf a₁ a₂ a₃ a₄))
+  · intro h f
+    have hf := h (fun a₁ a₂ a₃ a₄ => ((f a₁ a₂ a₃ a₄ : Nat) : Int)) (fun a₁ a₂ a₃ a₄ => by
+      constructor
+      · exact Int.natCast_nonneg (f a₁ a₂ a₃ a₄).val
+      · exact Int.ofNat_lt.mpr (f a₁ a₂ a₃ a₄).isLt)
+    simpa [ofIntFin_of_fin] using hf
+
+@[embedding ↓]
+theorem forall_fin_out_as_int₅ {n : Nat} {p : (α₁ → α₂ → α₃ → α₄ → α₅ → Fin n) → Prop} :
+    (∀ f : α₁ → α₂ → α₃ → α₄ → α₅ → Fin n, p f) ↔
+    (∀ f : α₁ → α₂ → α₃ → α₄ → α₅ → Int,
+      (hf : ∀ a₁ a₂ a₃ a₄ a₅, 0 ≤ f a₁ a₂ a₃ a₄ a₅ ∧ f a₁ a₂ a₃ a₄ a₅ < n) →
+      p (fun a₁ a₂ a₃ a₄ a₅ => ofIntFin n (f a₁ a₂ a₃ a₄ a₅) (hf a₁ a₂ a₃ a₄ a₅))) := by
+  constructor
+  · intro h f hf
+    exact h (fun a₁ a₂ a₃ a₄ a₅ => ofIntFin n (f a₁ a₂ a₃ a₄ a₅) (hf a₁ a₂ a₃ a₄ a₅))
+  · intro h f
+    have hf := h (fun a₁ a₂ a₃ a₄ a₅ => ((f a₁ a₂ a₃ a₄ a₅ : Nat) : Int))
+      (fun a₁ a₂ a₃ a₄ a₅ => by
+        constructor
+        · exact Int.natCast_nonneg (f a₁ a₂ a₃ a₄ a₅).val
+        · exact Int.ofNat_lt.mpr (f a₁ a₂ a₃ a₄ a₅).isLt)
+    simpa [ofIntFin_of_fin] using hf
+
+@[embedding ↓]
+theorem forall_fin_in_as_int₁ {n : Nat} [NeZero n] {p : (Fin n → α₁) → Prop} :
+    (∀ f : Fin n → α₁, p f) ↔
+    (∀ f : Int → α₁, p (fun a => f ((a : Nat) : Int))) := by
+  constructor
+  · intro h f
+    exact h (fun a => f ((a : Nat) : Int))
+  · intro h f
+    have hf := h (fun b => f (ofIntFinTotal n b))
+    simpa [ofIntFinTotal_of_fin] using hf
+
+@[embedding ↓]
+theorem forall_fin_in_as_int₂ {n : Nat} [NeZero n] {p : (α₁ → Fin n → α₂) → Prop} :
+    (∀ f : α₁ → Fin n → α₂, p f) ↔
+    (∀ f : α₁ → Int → α₂, p (fun a₁ a => f a₁ ((a : Nat) : Int))) := by
+  constructor
+  · intro h f
+    exact h (fun a₁ a => f a₁ ((a : Nat) : Int))
+  · intro h f
+    have hf := h (fun a₁ b => f a₁ (ofIntFinTotal n b))
+    simpa [ofIntFinTotal_of_fin] using hf
+
+@[embedding ↓]
+theorem forall_fin_in_as_int₃ {n : Nat} [NeZero n] {p : (α₁ → α₂ → Fin n → α₃) → Prop} :
+    (∀ f : α₁ → α₂ → Fin n → α₃, p f) ↔
+    (∀ f : α₁ → α₂ → Int → α₃, p (fun a₁ a₂ a => f a₁ a₂ ((a : Nat) : Int))) := by
+  constructor
+  · intro h f
+    exact h (fun a₁ a₂ a => f a₁ a₂ ((a : Nat) : Int))
+  · intro h f
+    have hf := h (fun a₁ a₂ b => f a₁ a₂ (ofIntFinTotal n b))
+    simpa [ofIntFinTotal_of_fin] using hf
+
+@[embedding ↓]
+theorem forall_fin_in_as_int₄ {n : Nat} [NeZero n] {p : (α₁ → α₂ → α₃ → Fin n → α₄) → Prop} :
+    (∀ f : α₁ → α₂ → α₃ → Fin n → α₄, p f) ↔
+    (∀ f : α₁ → α₂ → α₃ → Int → α₄, p (fun a₁ a₂ a₃ a => f a₁ a₂ a₃ ((a : Nat) : Int))) := by
+  constructor
+  · intro h f
+    exact h (fun a₁ a₂ a₃ a => f a₁ a₂ a₃ ((a : Nat) : Int))
+  · intro h f
+    have hf := h (fun a₁ a₂ a₃ b => f a₁ a₂ a₃ (ofIntFinTotal n b))
+    simpa [ofIntFinTotal_of_fin] using hf
+
+@[embedding ↓]
+theorem forall_fin_in_as_int₅ {n : Nat} [NeZero n] {p : (α₁ → α₂ → α₃ → α₄ → Fin n → α₅) → Prop} :
+    (∀ f : α₁ → α₂ → α₃ → α₄ → Fin n → α₅, p f) ↔
+    (∀ f : α₁ → α₂ → α₃ → α₄ → Int → α₅,
+      p (fun a₁ a₂ a₃ a₄ a => f a₁ a₂ a₃ a₄ ((a : Nat) : Int))) := by
+  constructor
+  · intro h f
+    exact h (fun a₁ a₂ a₃ a₄ a => f a₁ a₂ a₃ a₄ ((a : Nat) : Int))
+  · intro h f
+    have hf := h (fun a₁ a₂ a₃ a₄ b => f a₁ a₂ a₃ a₄ (ofIntFinTotal n b))
+    simpa [ofIntFinTotal_of_fin] using hf
+
+end Smt.Preprocess.Embedding

--- a/Smt/Translate/Int.lean
+++ b/Smt/Translate/Int.lean
@@ -10,6 +10,7 @@ import Smt.Translate
 
 namespace Smt.Translate.Int
 
+open Lean Expr
 open Translator Term
 
 private def mkInt : Lean.Expr :=
@@ -22,6 +23,8 @@ private def mkInt : Lean.Expr :=
 @[smt_translate] def translateInt : Translator := fun e => do
   if let some n := e.natLitOf? mkInt then
     return literalT (toString n)
+  else if let some n := natCastInt? e then
+    return ← applyTranslators! n
   else if let some x := e.negOf? mkInt then
     return appT (symbolT "-") (← applyTranslators! x)
   else if let some (x, y) := e.hAddOf? mkInt mkInt then
@@ -36,6 +39,11 @@ private def mkInt : Lean.Expr :=
     return mkApp2 (symbolT "mod") (← applyTranslators! x) (← applyTranslators! y)
   else
     return none
+where
+  natCastInt? : Expr → Option Expr
+    | .app (.app (.app (.const ``Nat.cast _) α) _) n =>
+      if α.consumeMData == mkInt then some n else none
+    | _ => none
 
 @[smt_translate] def translateProp : Translator := fun e => do
   if let some (x, y) := e.ltOf? mkInt then

--- a/Test/Bool/Assoc.expected
+++ b/Test/Bool/Assoc.expected
@@ -1,6 +1,6 @@
 Test/Bool/Assoc.lean:5:2: error: unable to prove goal, either it is false or you need to provide more facts. Here is a potential counter-example:
 
-  f = fun _arg_1 _arg_2 => if _arg_1 then ¬_arg_2 else ¬_arg_1 ∧ ¬_arg_2
-  p = True
-  q = False
   r = False
+  p = True
+  f = fun _arg_1 _arg_2 => if _arg_1 then ¬_arg_2 else ¬_arg_1 ∧ ¬_arg_2
+  q = False

--- a/Test/Bool/Comm.expected
+++ b/Test/Bool/Comm.expected
@@ -1,5 +1,5 @@
 Test/Bool/Comm.lean:4:2: error: unable to prove goal, either it is false or you need to provide more facts. Here is a potential counter-example:
 
-  p = False
   q = True
+  p = False
   f = fun _arg_1 _arg_2 => _arg_1 ∧ ¬_arg_2

--- a/Test/Fin.expected
+++ b/Test/Fin.expected
@@ -1,0 +1,2 @@
+Test/Fin.lean:3:67: error: unable to prove goal, either it is false or you need to provide more facts. Try adding '+model' config option to display a potential counter-example (experimental).
+Test/Fin.lean:5:71: error: unable to prove goal, either it is false or you need to provide more facts. Try adding '+model' config option to display a potential counter-example (experimental).

--- a/Test/Fin.lean
+++ b/Test/Fin.lean
@@ -1,0 +1,11 @@
+import Smt
+
+theorem nat_embedding (f : Nat → Nat → Bool) : f 0 0 = false := by smt
+
+theorem fin_embedding (f : Fin 4 → Fin 4 → Bool) : f 0 0 = false := by smt
+
+theorem fin_bound_free (x : Fin 4) : (x : Nat) < 4 := by smt
+
+theorem fin_bound_output (g : Nat → Fin 4) (a : Nat) : ((g a : Fin 4) : Nat) < 4 := by smt
+
+theorem fin_input_literal (f : Fin 4 → Fin 4 → Bool) : f 0 0 = f 0 0 := by smt


### PR DESCRIPTION
Currently, `Fin` is not handled by the embedding:

```lean
import Smt
-- cannot translate 0
theorem fin_embedding (f : Fin 4 → Fin 4 → Bool) : f 0 0 = false := by smt
```

This PR (written by Codex 5.5 with xhigh effort) mirrors the embedding done for Nat and does the same for `Fin n`.